### PR TITLE
Fix design flaw in writeAccess

### DIFF
--- a/VirtualSMC/kern_keystore.cpp
+++ b/VirtualSMC/kern_keystore.cpp
@@ -782,7 +782,7 @@ SMC_RESULT VirtualSMCKeystore::writeValueByName(SMC_KEY key, const SMC_DATA *dat
 			return SmcNotReadable;
 		
 		// Update internal buffers
-		res = currval->writeAccess();
+		res = currval->writeAccess(data);
 		if (res == SmcSuccess) {
 			res = currval->update(data);
 		}

--- a/VirtualSMCSDK/kern_value.hpp
+++ b/VirtualSMCSDK/kern_value.hpp
@@ -70,9 +70,11 @@ protected:
 	 *  On write access, update the data if needed, and perform custom access control.
 	 *  For base value, always allow the access if keystore allowed it.
 	 *
+	 *  @param  new_data   New data to be written if SmcSuccess is returned
+	 *
 	 *  @return SmcSuccess if allowed
 	 */
-	virtual SMC_RESULT writeAccess() {
+	virtual SMC_RESULT writeAccess(const SMC_DATA *new_data) {
 		return SmcSuccess;
 	}
 


### PR DESCRIPTION
There is a design flaw in method VirtualSMCKeystore::writeValueByName.
 
The value is updated only when writeAccess return SmcSuccess, and the new value is not sent to writeAccess at all. However, there are cases when the plugin needs to check the new value before accepting it.

This pull request fixes it by sending new value as a parameter in writeAccess