### PR TITLE
Fix battery stats update

### DIFF
--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -174,14 +174,14 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	bool bogus = false;
 	switch (st.state & BSTStateMask) {
 		case BSTFullyCharged: {
-			if (!batteryIsFull) {
+			if (!st.batteryIsFull) {
 				DBGLOG("acpib", "battery %d full, need stats update", id);
 				st.needUpdate = true;
 			} else {
 				DBGLOG("acpib", "battery %d full", id);
 			}
 			st.calculatedACAdapterConnected = true;
-			batteryIsFull = true;
+			st.batteryIsFull = true;
 			st.timeToFull = 0;
 			st.signedPresentRate = st.presentRate;
 			st.signedAverageRate = st.averageRate;
@@ -195,7 +195,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 				DBGLOG("acpib", "battery %d discharging", id);
 			}
 			st.calculatedACAdapterConnected = false;
-			batteryIsFull = false;
+			st.batteryIsFull = false;
 			st.timeToFull = 0;
 			st.signedPresentRate = -st.presentRate;
 			st.signedAverageRate = -st.averageRate;
@@ -204,7 +204,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		case BSTCharging: {
 			DBGLOG("acpib", "battery %d charging", id);
 			st.calculatedACAdapterConnected = true;
-			batteryIsFull = false;
+			st.batteryIsFull = false;
 			int diff = st.remainingCapacity < st.lastFullChargeCapacity ? st.lastFullChargeCapacity - st.remainingCapacity : 0;
 			st.timeToFull = st.averageRate ? 60 * diff / st.averageRate : 60 * diff;
 			st.signedPresentRate = st.presentRate;
@@ -213,7 +213,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		}
 		default: {
 			SYSLOG("acpib", "bogus status data from battery %d (%x)", id, st.state);
-			batteryIsFull = false;
+			st.batteryIsFull = false;
 			bogus = true;
 			break;
 		}
@@ -241,7 +241,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	IOSimpleLockUnlock(batteryInfoLock);
 
 	// one more poll when a stats update is needed but already full
-	return (st.needUpdate ? false : batteryIsFull);
+	return (st.needUpdate ? false : st.batteryIsFull);
 }
 
 bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -240,7 +240,8 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	batteryInfo->state = st;
 	IOSimpleLockUnlock(batteryInfoLock);
 
-	return st.batteryIsFull;
+	// one more poll when a stats update is needed but already full
+	return (st.needUpdate ? false : st.batteryIsFull);
 }
 
 bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -83,7 +83,7 @@ bool ACPIBattery::getBatteryInfo(BatteryInfo &bi, bool extended) {
 
 	info->release();
 
-	bi.validateData();
+	bi.validateData(id);
 
 	if (!extended) {
 		// Assume battery designed for 1000 cycles
@@ -177,8 +177,8 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	switch (st.state & BSTStateMask) {
 		case BSTFullyCharged: {
 			if (!batteryIsFull) {
-				DBGLOG("acpib", "battery %d charged", id);
-				st.updateStats = true;
+				DBGLOG("acpib", "battery %d full, need stats update", id);
+				st.needUpdate = true;
 			}
 			else {
 				DBGLOG("acpib", "battery %d full", id);
@@ -192,8 +192,8 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		}
 		case BSTDischarging: {
 			if (st.calculatedACAdapterConnected) {
-				DBGLOG("acpib", "battery %d discharging start", id);
-				st.updateStats = true;
+				DBGLOG("acpib", "battery %d discharging, need stats update", id);
+				st.needUpdate = true;
 			}
 			else {
 				DBGLOG("acpib", "battery %d discharging", id);
@@ -259,7 +259,7 @@ bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {
 
 		bool connected = (acpi & 0x10) ? true : false;
 		IOSimpleLockLock(batteryInfoLock);
-		if (connected == batteryInfo->connected && !batteryInfo->state.updateStats) {
+		if (connected == batteryInfo->connected && !batteryInfo->state.needUpdate) {
 			// No status change, most likely, just continue
 			if (calculatedACAdapterConnection)
 				*calculatedACAdapterConnection = batteryInfo->state.calculatedACAdapterConnected;

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -177,8 +177,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 			if (!st.batteryIsFull) {
 				DBGLOG("acpib", "battery %d full, need stats update", id);
 				st.needUpdate = true;
-			}
-			else {
+			} else {
 				DBGLOG("acpib", "battery %d full", id);
 			}
 			st.calculatedACAdapterConnected = true;
@@ -192,8 +191,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 			if (st.calculatedACAdapterConnected) {
 				DBGLOG("acpib", "battery %d discharging, need stats update", id);
 				st.needUpdate = true;
-			}
-			else {
+			} else {
 				DBGLOG("acpib", "battery %d discharging", id);
 			}
 			st.calculatedACAdapterConnected = false;

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -174,14 +174,14 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	bool bogus = false;
 	switch (st.state & BSTStateMask) {
 		case BSTFullyCharged: {
-			if (!st.batteryIsFull) {
+			if (!batteryIsFull) {
 				DBGLOG("acpib", "battery %d full, need stats update", id);
 				st.needUpdate = true;
 			} else {
 				DBGLOG("acpib", "battery %d full", id);
 			}
 			st.calculatedACAdapterConnected = true;
-			st.batteryIsFull = true;
+			batteryIsFull = true;
 			st.timeToFull = 0;
 			st.signedPresentRate = st.presentRate;
 			st.signedAverageRate = st.averageRate;
@@ -195,7 +195,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 				DBGLOG("acpib", "battery %d discharging", id);
 			}
 			st.calculatedACAdapterConnected = false;
-			st.batteryIsFull = false;
+			batteryIsFull = false;
 			st.timeToFull = 0;
 			st.signedPresentRate = -st.presentRate;
 			st.signedAverageRate = -st.averageRate;
@@ -204,7 +204,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		case BSTCharging: {
 			DBGLOG("acpib", "battery %d charging", id);
 			st.calculatedACAdapterConnected = true;
-			st.batteryIsFull = false;
+			batteryIsFull = false;
 			int diff = st.remainingCapacity < st.lastFullChargeCapacity ? st.lastFullChargeCapacity - st.remainingCapacity : 0;
 			st.timeToFull = st.averageRate ? 60 * diff / st.averageRate : 60 * diff;
 			st.signedPresentRate = st.presentRate;
@@ -213,7 +213,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		}
 		default: {
 			SYSLOG("acpib", "bogus status data from battery %d (%x)", id, st.state);
-			st.batteryIsFull = false;
+			batteryIsFull = false;
 			bogus = true;
 			break;
 		}
@@ -241,7 +241,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	IOSimpleLockUnlock(batteryInfoLock);
 
 	// one more poll when a stats update is needed but already full
-	return (st.needUpdate ? false : st.batteryIsFull);
+	return (st.needUpdate ? false : batteryIsFull);
 }
 
 bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -276,8 +276,9 @@ bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {
 			IOSimpleLockUnlock(batteryInfoLock);
 			BatteryInfo bi;
 			bi.connected = true;
-			if (!getBatteryInfo(bi, true) && !getBatteryInfo(bi, false))
-				bi.connected = false;
+			if (!getBatteryInfo(bi, true))
+				if (!getBatteryInfo(bi, false))
+					bi.connected = false;
 
 			if (calculatedACAdapterConnection)
 				*calculatedACAdapterConnection = bi.state.calculatedACAdapterConnected;

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -273,9 +273,8 @@ bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {
 			IOSimpleLockUnlock(batteryInfoLock);
 			BatteryInfo bi;
 			bi.connected = true;
-			if (!getBatteryInfo(bi, true))
-				if (!getBatteryInfo(bi, false))
-					bi.connected = false;
+			if (!getBatteryInfo(bi, true) && !getBatteryInfo(bi, false))
+				bi.connected = false;
 
 			if (calculatedACAdapterConnection)
 				*calculatedACAdapterConnection = bi.state.calculatedACAdapterConnected;

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -120,8 +120,6 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		return false;
 	}
 
-	bool batteryIsFull = false;
-
 	IOSimpleLockLock(batteryInfoLock);
 	auto st = batteryInfo->state;
 	IOSimpleLockUnlock(batteryInfoLock);
@@ -176,7 +174,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	bool bogus = false;
 	switch (st.state & BSTStateMask) {
 		case BSTFullyCharged: {
-			if (!batteryIsFull) {
+			if (!st.batteryIsFull) {
 				DBGLOG("acpib", "battery %d full, need stats update", id);
 				st.needUpdate = true;
 			}
@@ -184,7 +182,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 				DBGLOG("acpib", "battery %d full", id);
 			}
 			st.calculatedACAdapterConnected = true;
-			batteryIsFull = true;
+			st.batteryIsFull = true;
 			st.timeToFull = 0;
 			st.signedPresentRate = st.presentRate;
 			st.signedAverageRate = st.averageRate;
@@ -199,7 +197,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 				DBGLOG("acpib", "battery %d discharging", id);
 			}
 			st.calculatedACAdapterConnected = false;
-			batteryIsFull = false;
+			st.batteryIsFull = false;
 			st.timeToFull = 0;
 			st.signedPresentRate = -st.presentRate;
 			st.signedAverageRate = -st.averageRate;
@@ -208,7 +206,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		case BSTCharging: {
 			DBGLOG("acpib", "battery %d charging", id);
 			st.calculatedACAdapterConnected = true;
-			batteryIsFull = false;
+			st.batteryIsFull = false;
 			int diff = st.remainingCapacity < st.lastFullChargeCapacity ? st.lastFullChargeCapacity - st.remainingCapacity : 0;
 			st.timeToFull = st.averageRate ? 60 * diff / st.averageRate : 60 * diff;
 			st.signedPresentRate = st.presentRate;
@@ -217,7 +215,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 		}
 		default: {
 			SYSLOG("acpib", "bogus status data from battery %d (%x)", id, st.state);
-			batteryIsFull = false;
+			st.batteryIsFull = false;
 			bogus = true;
 			break;
 		}
@@ -244,7 +242,7 @@ bool ACPIBattery::updateRealTimeStatus(bool quickPoll) {
 	batteryInfo->state = st;
 	IOSimpleLockUnlock(batteryInfoLock);
 
-	return batteryIsFull;
+	return st.batteryIsFull;
 }
 
 bool ACPIBattery::updateStaticStatus(bool *calculatedACAdapterConnection) {

--- a/Sensors/SMCBatteryManager/ACPIBattery.hpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.hpp
@@ -132,6 +132,11 @@ private:
 	int32_t id {-1};
 
 	/**
+	 *  Current battery status
+	 */
+	bool batteryIsFull {false};
+
+	/**
 	 *  Current battery ACPI device
 	 */
 	IOACPIPlatformDevice *device {nullptr};

--- a/Sensors/SMCBatteryManager/ACPIBattery.hpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.hpp
@@ -132,11 +132,6 @@ private:
 	int32_t id {-1};
 
 	/**
-	 *  Current battery status
-	 */
-	bool batteryIsFull {false};
-
-	/**
 	 *  Current battery ACPI device
 	 */
 	IOACPIPlatformDevice *device {nullptr};

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -38,7 +38,7 @@ void BatteryInfo::validateData(int32_t id) {
 		}
 	}
 
-	SYSLOG("binfo", "battery %d cycle count %d remaining capacity %ld", id, cycle, state.lastFullChargeCapacity);
+	DBGLOG("binfo", "battery %d cycle count %d remaining capacity %ld", id, cycle, state.lastFullChargeCapacity);
 }
 
 void BatteryManager::checkDevices() {

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -11,14 +11,14 @@ BatteryManager *BatteryManager::instance = nullptr;
 
 OSDefineMetaClassAndStructors(BatteryManager, OSObject)
 
-void BatteryInfo::validateData() {
+void BatteryInfo::validateData(int32_t id) {
 	if (!state.designVoltage)
 		state.designVoltage = DummyVoltage;
 	if (state.powerUnitIsWatt) {
     auto mV = state.designVoltage;
 		DBGLOG("binfo", "battery voltage %d,%03d", mV / 1000, mV % 1000);
 		if (designCapacity * 1000 / mV < 900) {
-			SYSLOG("binfo", "battery reports mWh but uses mAh (%u)", designCapacity);
+			SYSLOG("binfo", "battery %d reports mWh but uses mAh (%u)", id, designCapacity);
 			state.powerUnitIsWatt = false;
 		} else {
 			designCapacity = designCapacity * 1000 / mV;
@@ -29,7 +29,7 @@ void BatteryInfo::validateData() {
 	}
 
 	if (designCapacity < state.lastFullChargeCapacity) {
-		SYSLOG("binfo", "battery reports lower design capacity than maximum charged (%u/%u)",
+		SYSLOG("binfo", "battery %d reports lower design capacity than maximum charged (%u/%u)", id,
 			   designCapacity, state.lastFullChargeCapacity);
 		if (state.lastFullChargeCapacity < ValueMax) {
 			auto temp = designCapacity;
@@ -38,7 +38,7 @@ void BatteryInfo::validateData() {
 		}
 	}
 
-	SYSLOG("binfo", "battery cycle count %d remaining capacity %ld", cycle, state.lastFullChargeCapacity);
+	SYSLOG("binfo", "battery %d cycle count %d remaining capacity %ld", id, cycle, state.lastFullChargeCapacity);
 }
 
 void BatteryManager::checkDevices() {

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -16,7 +16,7 @@ void BatteryInfo::validateData(int32_t id) {
 		state.designVoltage = DummyVoltage;
 	if (state.powerUnitIsWatt) {
     auto mV = state.designVoltage;
-		DBGLOG("binfo", "battery voltage %d,%03d", mV / 1000, mV % 1000);
+		DBGLOG("binfo", "battery %d voltage %d,%03d", id, mV / 1000, mV % 1000);
 		if (designCapacity * 1000 / mV < 900) {
 			SYSLOG("binfo", "battery %d reports mWh but uses mAh (%u)", id, designCapacity);
 			state.powerUnitIsWatt = false;

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -37,6 +37,8 @@ void BatteryInfo::validateData() {
 			state.lastFullChargeCapacity = temp;
 		}
 	}
+
+	SYSLOG("binfo", "battery cycle count %d remaining capacity %ld", cycle, state.lastFullChargeCapacity);
 }
 
 void BatteryManager::checkDevices() {

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -16,7 +16,7 @@ void BatteryInfo::validateData(int32_t id) {
 		state.designVoltage = DummyVoltage;
 	if (state.powerUnitIsWatt) {
     auto mV = state.designVoltage;
-		DBGLOG("binfo", "battery %d voltage %d,%03d", id, mV / 1000, mV % 1000);
+		DBGLOG("binfo", "battery %d design voltage %d,%03d", id, mV / 1000, mV % 1000);
 		if (designCapacity * 1000 / mV < 900) {
 			SYSLOG("binfo", "battery %d reports mWh but uses mAh (%u)", id, designCapacity);
 			state.powerUnitIsWatt = false;

--- a/Sensors/SMCBatteryManager/BatteryManagerState.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManagerState.hpp
@@ -56,7 +56,7 @@ struct BatteryInfo {
 		bool bad {false};
 		bool bogus {false};
 		bool critical {false};
-		bool updateStats {false};
+		bool needUpdate {false};
 	};
 
 	/**
@@ -74,8 +74,10 @@ struct BatteryInfo {
 
 	/**
 	 *  Validate battery information and set the defaults
+	 *
+	 *  @param id        battery id
 	 */
-	void validateData();
+	void validateData(int32_t id=-1);
 };
 
 /**

--- a/Sensors/SMCBatteryManager/BatteryManagerState.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManagerState.hpp
@@ -56,6 +56,7 @@ struct BatteryInfo {
 		bool bad {false};
 		bool bogus {false};
 		bool critical {false};
+		bool batteryIsFull {false};
 		bool needUpdate {false};
 	};
 

--- a/Sensors/SMCBatteryManager/BatteryManagerState.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManagerState.hpp
@@ -56,6 +56,7 @@ struct BatteryInfo {
 		bool bad {false};
 		bool bogus {false};
 		bool critical {false};
+		bool updateStats {false};
 	};
 
 	/**

--- a/Sensors/SMCBatteryManager/BatteryManagerState.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManagerState.hpp
@@ -56,7 +56,7 @@ struct BatteryInfo {
 		bool bad {false};
 		bool bogus {false};
 		bool critical {false};
-		bool batteryIsFull {false};
+		bool batteryIsFull {true};
 		bool needUpdate {false};
 	};
 

--- a/Sensors/SMCBatteryManager/BatteryManagerState.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManagerState.hpp
@@ -56,7 +56,6 @@ struct BatteryInfo {
 		bool bad {false};
 		bool bogus {false};
 		bool critical {false};
-		bool batteryIsFull {false};
 		bool needUpdate {false};
 	};
 


### PR DESCRIPTION
Some information from _BIF / _BIX like cycle count and last full charge capacity will only be updated after a restart for internal batteries. The update is triggered when a battery's state changes to full or discharging.

Battery id is added for logging in validateData. New log of battery cycle and full charge capacity is shown by default for records.

When _BIX and _BIF both present (maybe rare?), batteryinfo will be overrode by latter one with fewer information. When I constructed _BIX over the old _BIF one, _BIF have to be renamed to avoid that.