### PR TITLE
Fix audio lags in Safari caused by reading SMM in SMCDellSensors plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ VirtualSMC Changelog
 #### 1.1.6
 - Added battery supplement info, thx @zhen-zen
 - Fix audio lags in Safari caused by reading SMM in SMCDellSensors plugin
+- Fix module version for SMCDellSensors, SMCBatteryManager and SMCLightSensor
 
 #### v1.1.5
 - Improved CHLC key value reporting

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ VirtualSMC Changelog
 ====================
 #### 1.1.6
 - Added battery supplement info, thx @zhen-zen
+- Fix audio lags in Safari caused by reading SMM in SMCDellSensors plugin
 
 #### v1.1.5
 - Improved CHLC key value reporting

--- a/Sensors/SMCBatteryManager/Info.plist
+++ b/Sensors/SMCBatteryManager/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MODULE_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(MODULE_VERSION)</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>IOSMBusController</key>

--- a/Sensors/SMCDellSensors/Info.plist
+++ b/Sensors/SMCDellSensors/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MODULE_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(MODULE_VERSION)</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>SMCDellSensors</key>

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -12,66 +12,64 @@
 
 SMIMonitor *SMIMonitor::instance = nullptr;
 
-#define super OSObject
 OSDefineMetaClassAndStructors(SMIMonitor, OSObject)
 
-static int smm(SMMRegisters *regs)
-{
+static int smm(SMMRegisters *regs) {
 	int rc;
 	int eax = regs->eax;  //input value
 
 #if __LP64__
 	asm volatile("pushq %%rax\n\t"
-			   "movl 0(%%rax),%%edx\n\t"
-			   "pushq %%rdx\n\t"
-			   "movl 4(%%rax),%%ebx\n\t"
-			   "movl 8(%%rax),%%ecx\n\t"
-			   "movl 12(%%rax),%%edx\n\t"
-			   "movl 16(%%rax),%%esi\n\t"
-			   "movl 20(%%rax),%%edi\n\t"
-			   "popq %%rax\n\t"
-			   "out %%al,$0xb2\n\t"
-			   "out %%al,$0x84\n\t"
-			   "xchgq %%rax,(%%rsp)\n\t"
-			   "movl %%ebx,4(%%rax)\n\t"
-			   "movl %%ecx,8(%%rax)\n\t"
-			   "movl %%edx,12(%%rax)\n\t"
-			   "movl %%esi,16(%%rax)\n\t"
-			   "movl %%edi,20(%%rax)\n\t"
-			   "popq %%rdx\n\t"
-			   "movl %%edx,0(%%rax)\n\t"
-			   "pushfq\n\t"
-			   "popq %%rax\n\t"
-			   "andl $1,%%eax\n"
-			   : "=a"(rc)
-			   :    "a"(regs)
-			   :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
+			"movl 0(%%rax),%%edx\n\t"
+			"pushq %%rdx\n\t"
+			"movl 4(%%rax),%%ebx\n\t"
+			"movl 8(%%rax),%%ecx\n\t"
+			"movl 12(%%rax),%%edx\n\t"
+			"movl 16(%%rax),%%esi\n\t"
+			"movl 20(%%rax),%%edi\n\t"
+			"popq %%rax\n\t"
+			"out %%al,$0xb2\n\t"
+			"out %%al,$0x84\n\t"
+			"xchgq %%rax,(%%rsp)\n\t"
+			"movl %%ebx,4(%%rax)\n\t"
+			"movl %%ecx,8(%%rax)\n\t"
+			"movl %%edx,12(%%rax)\n\t"
+			"movl %%esi,16(%%rax)\n\t"
+			"movl %%edi,20(%%rax)\n\t"
+			"popq %%rdx\n\t"
+			"movl %%edx,0(%%rax)\n\t"
+			"pushfq\n\t"
+			"popq %%rax\n\t"
+			"andl $1,%%eax\n"
+			: "=a"(rc)
+			: "a"(regs)
+			: "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #else
 	asm volatile("pushl %%eax\n\t"
-			   "movl 0(%%eax),%%edx\n\t"
-			   "push %%edx\n\t"
-			   "movl 4(%%eax),%%ebx\n\t"
-			   "movl 8(%%eax),%%ecx\n\t"
-			   "movl 12(%%eax),%%edx\n\t"
-			   "movl 16(%%eax),%%esi\n\t"
-			   "movl 20(%%eax),%%edi\n\t"
-			   "popl %%eax\n\t"
-			   "out %%al,$0xb2\n\t"
-			   "out %%al,$0x84\n\t"
-			   "xchgl %%eax,(%%esp)\n\t"
-			   "movl %%ebx,4(%%eax)\n\t"
-			   "movl %%ecx,8(%%eax)\n\t"
-			   "movl %%edx,12(%%eax)\n\t"
-			   "movl %%esi,16(%%eax)\n\t"
-			   "movl %%edi,20(%%eax)\n\t"
-			   "popl %%edx\n\t"
-			   "movl %%edx,0(%%eax)\n\t"
-			   "lahf\n\t"
-			   "shrl $8,%%eax\n\t"
-			   "andl $1,%%eax\n"
-			   : "=a"(rc)
-			   :    "a"(regs)
-			   :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
+			"movl 0(%%eax),%%edx\n\t"
+			"push %%edx\n\t"
+			"movl 4(%%eax),%%ebx\n\t"
+			"movl 8(%%eax),%%ecx\n\t"
+			"movl 12(%%eax),%%edx\n\t"
+			"movl 16(%%eax),%%esi\n\t"
+			"movl 20(%%eax),%%edi\n\t"
+			"popl %%eax\n\t"
+			"out %%al,$0xb2\n\t"
+			"out %%al,$0x84\n\t"
+			"xchgl %%eax,(%%esp)\n\t"
+			"movl %%ebx,4(%%eax)\n\t"
+			"movl %%ecx,8(%%eax)\n\t"
+			"movl %%edx,12(%%eax)\n\t"
+			"movl %%esi,16(%%eax)\n\t"
+			"movl %%edi,20(%%eax)\n\t"
+			"popl %%edx\n\t"
+			"movl %%edx,0(%%eax)\n\t"
+			"lahf\n\t"
+			"shrl $8,%%eax\n\t"
+			"andl $1,%%eax\n"
+			: "=a"(rc)
+			: "a"(regs)
+			: "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #endif
 
 	if ((rc != 0) || ((regs->eax & 0xffff) == 0xffff) || (regs->eax == eax)) {
@@ -81,15 +79,12 @@ static int smm(SMMRegisters *regs)
 	return 0;
 }
 
-int SMIMonitor::i8k_smm(SMMRegisters *regs)
-{
+int SMIMonitor::i8k_smm(SMMRegisters *regs) {
 	static int gRc;
 	gRc = -1;
 	mp_rendezvous_no_intrs([](void *arg) {
-		volatile UInt32 i = cpu_number();
-		if (i == 0) { /* SMM requires CPU 0 */
-			SMMRegisters *regs = (SMMRegisters *)arg;
-			gRc = smm(regs);
+		if (cpu_number() == 0) { /* SMM requires CPU 0 */
+			gRc = smm(static_cast<SMMRegisters *>(arg));
 		}
 	}, regs);
 	return gRc;
@@ -99,7 +94,7 @@ int SMIMonitor::i8k_smm(SMMRegisters *regs)
  * Read the CPU temperature in Celcius.
  */
 int SMIMonitor::i8k_get_temp(int sensor) {
-	INIT_REGS;
+	SMMRegisters regs {};
 	int rc;
 	int temp;
 
@@ -123,14 +118,14 @@ int SMIMonitor::i8k_get_temp(int sensor) {
 }
 
 int SMIMonitor::i8k_get_temp_type(int sensor) {
-	INIT_REGS;
+	SMMRegisters regs {};
 	int rc;
 	int type;
 
 	regs.eax = I8K_SMM_GET_TEMP_TYPE;
 	regs.ebx = sensor & 0xFF;
 	if ((rc=i8k_smm(&regs)) < 0) {
-	return rc;
+		return rc;
 	}
 
 	type = regs.eax & 0xff;
@@ -138,16 +133,16 @@ int SMIMonitor::i8k_get_temp_type(int sensor) {
 }
 
 bool SMIMonitor::i8k_get_dell_sig_aux(int fn) {
-	INIT_REGS;
+	SMMRegisters regs {};
 
 	regs.eax = fn;
 	if (i8k_smm(&regs) < 0) {
-	DBGLOG("sdell", "No function 0x%x", fn);
+		DBGLOG("sdell", "No function 0x%x", fn);
 		return false;
 	}
 	DBGLOG("sdell", "Got sigs %x and %x", regs.eax, regs.edx);
-		return ((regs.eax == 0x44494147 /*DIAG*/) &&
-				(regs.edx == 0x44454C4C /*DELL*/));
+	return ((regs.eax == 0x44494147 /*DIAG*/) &&
+			(regs.edx == 0x44454C4C /*DELL*/));
 }
 
 bool SMIMonitor::i8k_get_dell_signature(void) {
@@ -159,7 +154,7 @@ bool SMIMonitor::i8k_get_dell_signature(void) {
  * Read the fan speed in RPM.
  */
 int SMIMonitor::i8k_get_fan_speed(int fan) {
-	INIT_REGS;
+	SMMRegisters regs {};
 	int rc;
 	int speed = 0;
 
@@ -176,7 +171,7 @@ int SMIMonitor::i8k_get_fan_speed(int fan) {
  * Read the fan status.
  */
 int SMIMonitor::i8k_get_fan_status(int fan) {
-	INIT_REGS;
+	SMMRegisters regs {};
 	int rc;
 
 	regs.eax = I8K_SMM_GET_FAN;
@@ -192,7 +187,7 @@ int SMIMonitor::i8k_get_fan_status(int fan) {
  * Read the fan status.
  */
 int SMIMonitor::i8k_get_fan_type(int fan) {
-	INIT_REGS;
+	SMMRegisters regs {};
 	int rc;
 
 	regs.eax = I8K_SMM_GET_FAN_TYPE;
@@ -208,9 +203,8 @@ int SMIMonitor::i8k_get_fan_type(int fan) {
 /*
  * Read the fan nominal rpm for specific fan speed (0,1,2) or zero
  */
-int SMIMonitor::i8k_get_fan_nominal_speed(int fan, int speed)
-{
-	INIT_REGS;
+int SMIMonitor::i8k_get_fan_nominal_speed(int fan, int speed) {
+	SMMRegisters regs {};
 	regs.eax = I8K_SMM_GET_NOM_SPEED;
 	regs.ebx = (fan & 0xff) | (speed << 8);
 	return i8k_smm(&regs) ? 0 : (regs.eax & 0xffff) * fanMult;
@@ -219,9 +213,8 @@ int SMIMonitor::i8k_get_fan_nominal_speed(int fan, int speed)
 /*
  * Set the fan speed (off, low, high). Returns the new fan status.
  */
-int SMIMonitor::i8k_set_fan(int fan, int speed)
-{
-	INIT_REGS;
+int SMIMonitor::i8k_set_fan(int fan, int speed) {
+	SMMRegisters regs {};
 	regs.eax = I8K_SMM_SET_FAN;
 
 	speed = (speed < 0) ? 0 : ((speed > I8K_FAN_MAX) ? I8K_FAN_MAX : speed);
@@ -230,17 +223,15 @@ int SMIMonitor::i8k_set_fan(int fan, int speed)
 	return i8k_smm(&regs);
 }
 
-int  SMIMonitor::i8k_set_fan_control_manual(int fan)
-{
-	INIT_REGS;
+int SMIMonitor::i8k_set_fan_control_manual(int fan) {
+	SMMRegisters regs {};
 	regs.eax = I8K_SMM_IO_DISABLE_FAN_CTL1;
 	regs.ebx = (fan & 0xff);
 	return i8k_smm(&regs);
 }
 
-int  SMIMonitor::i8k_set_fan_control_auto(int fan)
-{
-	INIT_REGS;
+int SMIMonitor::i8k_set_fan_control_auto(int fan) {
+	SMMRegisters regs {};
 	regs.eax = I8K_SMM_IO_ENABLE_FAN_CTL1;
 	regs.ebx = (fan & 0xff);
 	return i8k_smm(&regs);
@@ -257,8 +248,7 @@ void SMIMonitor::createShared() {
 		PANIC("sdell", "failed to allocate smi monitor main lock");
 }
 
-bool SMIMonitor::probe()
-{
+bool SMIMonitor::probe() {
 	IOLockLock(mainLock);
 	if (!i8k_get_dell_signature()) {
 		SYSLOG("sdell", "Unable to get Dell SMM signature!");
@@ -310,8 +300,7 @@ bool SMIMonitor::probe()
 	return success;
 }
 
-void SMIMonitor::start()
-{
+void SMIMonitor::start() {
 	IOLockLock(mainLock);
 	if (!initialUpdateSensors) {
 		for (int i=0; i<fanCount; ++i)
@@ -322,18 +311,15 @@ void SMIMonitor::start()
 	IOLockUnlock(mainLock);
 }
 
-void SMIMonitor::handlePowerOff()
-{
+void SMIMonitor::handlePowerOff() {
 	timerEventSource->disable();
 }
 
-void SMIMonitor::handlePowerOn()
-{
+void SMIMonitor::handlePowerOn() {
 	timerEventSource->enable();
 }
 
-bool SMIMonitor::findFanSensors()
-{
+bool SMIMonitor::findFanSensors() {
 	fanCount = 0;
 
 	for (int i = 0; i < state.MaxFanSupported; i++) {
@@ -360,8 +346,7 @@ bool SMIMonitor::findFanSensors()
 	return fanCount > 0;
 }
 
-bool SMIMonitor::findTempSensors()
-{
+bool SMIMonitor::findTempSensors() {
 	tempCount = 0;
 	
 	for (int i=0; i<state.MaxTempSupported; i++)
@@ -382,8 +367,7 @@ bool SMIMonitor::findTempSensors()
 	return tempCount > 0;
 }
 
-void SMIMonitor::updateSensors()
-{
+void SMIMonitor::updateSensors() {
 	if (timerEventSource == nullptr) {
 		DBGLOG("sdell", "WTF timerEventSource is null");
 		return;

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -17,80 +17,81 @@ OSDefineMetaClassAndStructors(SMIMonitor, OSObject)
 
 static int smm(SMMRegisters *regs)
 {
-  int rc;
-  int eax = regs->eax;  //input value
+	int rc;
+	int eax = regs->eax;  //input value
 
 #if __LP64__
-  asm volatile("pushq %%rax\n\t"
-               "movl 0(%%rax),%%edx\n\t"
-               "pushq %%rdx\n\t"
-               "movl 4(%%rax),%%ebx\n\t"
-               "movl 8(%%rax),%%ecx\n\t"
-               "movl 12(%%rax),%%edx\n\t"
-               "movl 16(%%rax),%%esi\n\t"
-               "movl 20(%%rax),%%edi\n\t"
-               "popq %%rax\n\t"
-               "out %%al,$0xb2\n\t"
-               "out %%al,$0x84\n\t"
-               "xchgq %%rax,(%%rsp)\n\t"
-               "movl %%ebx,4(%%rax)\n\t"
-               "movl %%ecx,8(%%rax)\n\t"
-               "movl %%edx,12(%%rax)\n\t"
-               "movl %%esi,16(%%rax)\n\t"
-               "movl %%edi,20(%%rax)\n\t"
-               "popq %%rdx\n\t"
-               "movl %%edx,0(%%rax)\n\t"
-               "pushfq\n\t"
-               "popq %%rax\n\t"
-               "andl $1,%%eax\n"
-               : "=a"(rc)
-               :    "a"(regs)
-               :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
+	asm volatile("pushq %%rax\n\t"
+			   "movl 0(%%rax),%%edx\n\t"
+			   "pushq %%rdx\n\t"
+			   "movl 4(%%rax),%%ebx\n\t"
+			   "movl 8(%%rax),%%ecx\n\t"
+			   "movl 12(%%rax),%%edx\n\t"
+			   "movl 16(%%rax),%%esi\n\t"
+			   "movl 20(%%rax),%%edi\n\t"
+			   "popq %%rax\n\t"
+			   "out %%al,$0xb2\n\t"
+			   "out %%al,$0x84\n\t"
+			   "xchgq %%rax,(%%rsp)\n\t"
+			   "movl %%ebx,4(%%rax)\n\t"
+			   "movl %%ecx,8(%%rax)\n\t"
+			   "movl %%edx,12(%%rax)\n\t"
+			   "movl %%esi,16(%%rax)\n\t"
+			   "movl %%edi,20(%%rax)\n\t"
+			   "popq %%rdx\n\t"
+			   "movl %%edx,0(%%rax)\n\t"
+			   "pushfq\n\t"
+			   "popq %%rax\n\t"
+			   "andl $1,%%eax\n"
+			   : "=a"(rc)
+			   :    "a"(regs)
+			   :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #else
-  asm volatile("pushl %%eax\n\t"
-               "movl 0(%%eax),%%edx\n\t"
-               "push %%edx\n\t"
-               "movl 4(%%eax),%%ebx\n\t"
-               "movl 8(%%eax),%%ecx\n\t"
-               "movl 12(%%eax),%%edx\n\t"
-               "movl 16(%%eax),%%esi\n\t"
-               "movl 20(%%eax),%%edi\n\t"
-               "popl %%eax\n\t"
-               "out %%al,$0xb2\n\t"
-               "out %%al,$0x84\n\t"
-               "xchgl %%eax,(%%esp)\n\t"
-               "movl %%ebx,4(%%eax)\n\t"
-               "movl %%ecx,8(%%eax)\n\t"
-               "movl %%edx,12(%%eax)\n\t"
-               "movl %%esi,16(%%eax)\n\t"
-               "movl %%edi,20(%%eax)\n\t"
-               "popl %%edx\n\t"
-               "movl %%edx,0(%%eax)\n\t"
-               "lahf\n\t"
-               "shrl $8,%%eax\n\t"
-               "andl $1,%%eax\n"
-               : "=a"(rc)
-               :    "a"(regs)
-               :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
+	asm volatile("pushl %%eax\n\t"
+			   "movl 0(%%eax),%%edx\n\t"
+			   "push %%edx\n\t"
+			   "movl 4(%%eax),%%ebx\n\t"
+			   "movl 8(%%eax),%%ecx\n\t"
+			   "movl 12(%%eax),%%edx\n\t"
+			   "movl 16(%%eax),%%esi\n\t"
+			   "movl 20(%%eax),%%edi\n\t"
+			   "popl %%eax\n\t"
+			   "out %%al,$0xb2\n\t"
+			   "out %%al,$0x84\n\t"
+			   "xchgl %%eax,(%%esp)\n\t"
+			   "movl %%ebx,4(%%eax)\n\t"
+			   "movl %%ecx,8(%%eax)\n\t"
+			   "movl %%edx,12(%%eax)\n\t"
+			   "movl %%esi,16(%%eax)\n\t"
+			   "movl %%edi,20(%%eax)\n\t"
+			   "popl %%edx\n\t"
+			   "movl %%edx,0(%%eax)\n\t"
+			   "lahf\n\t"
+			   "shrl $8,%%eax\n\t"
+			   "andl $1,%%eax\n"
+			   : "=a"(rc)
+			   :    "a"(regs)
+			   :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #endif
 
-  if ((rc != 0) || ((regs->eax & 0xffff) == 0xffff) || (regs->eax == eax)) {
-    return -1;
-  }
+	if ((rc != 0) || ((regs->eax & 0xffff) == 0xffff) || (regs->eax == eax)) {
+		return -1;
+	}
 
-  return 0;
+	return 0;
 }
 
 int SMIMonitor::i8k_smm(SMMRegisters *regs)
 {
 	static int gRc;
 	gRc = -1;
-	mp_rendezvous([](void *arg){}, [](void *arg){
-		SMMRegisters *regs = (SMMRegisters *)arg;
+	mp_rendezvous_no_intrs([](void *arg) {
 		volatile UInt32 i = cpu_number();
-		if (i == 0) /* SMM requires CPU 0 */
+		if (i == 0) { /* SMM requires CPU 0 */
+			SMMRegisters *regs = (SMMRegisters *)arg;
 			gRc = smm(regs);
-	}, [](void *arg){}, regs);
+		}
+	}, regs);
 	return gRc;
 }
 
@@ -98,109 +99,109 @@ int SMIMonitor::i8k_smm(SMMRegisters *regs)
  * Read the CPU temperature in Celcius.
  */
 int SMIMonitor::i8k_get_temp(int sensor) {
-  INIT_REGS;
-  int rc;
-  int temp;
+	INIT_REGS;
+	int rc;
+	int temp;
 
-  regs.eax = I8K_SMM_GET_TEMP;
-  regs.ebx = sensor & 0xFF;
-  if ((rc=i8k_smm(&regs)) < 0) {
-    return rc;
-  }
+	regs.eax = I8K_SMM_GET_TEMP;
+	regs.ebx = sensor & 0xFF;
+	if ((rc=i8k_smm(&regs)) < 0) {
+		return rc;
+	}
 
-  temp = regs.eax & 0xff;
-  if (temp == 0x99) {
-    IOSleep(100);
-    regs.eax = I8K_SMM_GET_TEMP;
-    regs.ebx = sensor & 0xFF;
-    if ((rc=i8k_smm(&regs)) < 0) {
-      return rc;
-    }
-    temp = regs.eax & 0xff;
-  }
-  return temp;
+	temp = regs.eax & 0xff;
+	if (temp == 0x99) {
+		IOSleep(100);
+		regs.eax = I8K_SMM_GET_TEMP;
+		regs.ebx = sensor & 0xFF;
+		if ((rc=i8k_smm(&regs)) < 0) {
+			return rc;
+		}
+		temp = regs.eax & 0xff;
+	}
+	return temp;
 }
 
 int SMIMonitor::i8k_get_temp_type(int sensor) {
-  INIT_REGS;
-  int rc;
-  int type;
+	INIT_REGS;
+	int rc;
+	int type;
 
-  regs.eax = I8K_SMM_GET_TEMP_TYPE;
-  regs.ebx = sensor & 0xFF;
-  if ((rc=i8k_smm(&regs)) < 0) {
-    return rc;
-  }
+	regs.eax = I8K_SMM_GET_TEMP_TYPE;
+	regs.ebx = sensor & 0xFF;
+	if ((rc=i8k_smm(&regs)) < 0) {
+	return rc;
+	}
 
-  type = regs.eax & 0xff;
-  return type;
+	type = regs.eax & 0xff;
+	return type;
 }
 
 bool SMIMonitor::i8k_get_dell_sig_aux(int fn) {
-  INIT_REGS;
+	INIT_REGS;
 
-  regs.eax = fn;
-  if (i8k_smm(&regs) < 0) {
-    DBGLOG("sdell", "No function 0x%x", fn);
-    return false;
-  }
-  DBGLOG("sdell", "Got sigs %x and %x", regs.eax, regs.edx);
-  return ((regs.eax == 0x44494147 /*DIAG*/) &&
-          (regs.edx == 0x44454C4C /*DELL*/));
+	regs.eax = fn;
+	if (i8k_smm(&regs) < 0) {
+	DBGLOG("sdell", "No function 0x%x", fn);
+		return false;
+	}
+	DBGLOG("sdell", "Got sigs %x and %x", regs.eax, regs.edx);
+		return ((regs.eax == 0x44494147 /*DIAG*/) &&
+				(regs.edx == 0x44454C4C /*DELL*/));
 }
 
 bool SMIMonitor::i8k_get_dell_signature(void) {
-  return (i8k_get_dell_sig_aux(I8K_SMM_GET_DELL_SIG1) ||
-          i8k_get_dell_sig_aux(I8K_SMM_GET_DELL_SIG2));
+	return (i8k_get_dell_sig_aux(I8K_SMM_GET_DELL_SIG1) ||
+		    i8k_get_dell_sig_aux(I8K_SMM_GET_DELL_SIG2));
 }
 
 /*
  * Read the fan speed in RPM.
  */
 int SMIMonitor::i8k_get_fan_speed(int fan) {
-  INIT_REGS;
-  int rc;
-  int speed = 0;
+	INIT_REGS;
+	int rc;
+	int speed = 0;
 
-  regs.eax = I8K_SMM_GET_SPEED;
-  regs.ebx = fan & 0xff;
-  if ((rc=i8k_smm(&regs)) < 0) {
-    return rc;
-  }
-  speed = (regs.eax & 0xffff) * fanMult;
-  return speed;
+	regs.eax = I8K_SMM_GET_SPEED;
+	regs.ebx = fan & 0xff;
+	if ((rc=i8k_smm(&regs)) < 0) {
+		return rc;
+	}
+	speed = (regs.eax & 0xffff) * fanMult;
+	return speed;
 }
 
 /*
  * Read the fan status.
  */
 int SMIMonitor::i8k_get_fan_status(int fan) {
-  INIT_REGS;
-  int rc;
+	INIT_REGS;
+	int rc;
 
-  regs.eax = I8K_SMM_GET_FAN;
-  regs.ebx = fan & 0xff;
-  if ((rc=i8k_smm(&regs)) < 0) {
-    return rc;
-  }
+	regs.eax = I8K_SMM_GET_FAN;
+	regs.ebx = fan & 0xff;
+	if ((rc=i8k_smm(&regs)) < 0) {
+		return rc;
+	}
 
-  return (regs.eax & 0xff);
+	return (regs.eax & 0xff);
 }
 
 /*
  * Read the fan status.
  */
 int SMIMonitor::i8k_get_fan_type(int fan) {
-  INIT_REGS;
-  int rc;
+	INIT_REGS;
+	int rc;
 
-  regs.eax = I8K_SMM_GET_FAN_TYPE;
-  regs.ebx = fan & 0xff;
-  if ((rc=i8k_smm(&regs)) < 0) {
-    return rc;
-  }
+	regs.eax = I8K_SMM_GET_FAN_TYPE;
+	regs.ebx = fan & 0xff;
+	if ((rc=i8k_smm(&regs)) < 0) {
+		return rc;
+	}
 
-  return (regs.eax & 0xff);
+	return (regs.eax & 0xff);
 }
 
 
@@ -209,10 +210,10 @@ int SMIMonitor::i8k_get_fan_type(int fan) {
  */
 int SMIMonitor::i8k_get_fan_nominal_speed(int fan, int speed)
 {
-  INIT_REGS;
-  regs.eax = I8K_SMM_GET_NOM_SPEED;
-  regs.ebx = (fan & 0xff) | (speed << 8);
-  return i8k_smm(&regs) ? 0 : (regs.eax & 0xffff) * fanMult;
+	INIT_REGS;
+	regs.eax = I8K_SMM_GET_NOM_SPEED;
+	regs.ebx = (fan & 0xff) | (speed << 8);
+	return i8k_smm(&regs) ? 0 : (regs.eax & 0xffff) * fanMult;
 }
 
 /*
@@ -220,29 +221,29 @@ int SMIMonitor::i8k_get_fan_nominal_speed(int fan, int speed)
  */
 int SMIMonitor::i8k_set_fan(int fan, int speed)
 {
-  INIT_REGS;
-  regs.eax = I8K_SMM_SET_FAN;
+	INIT_REGS;
+	regs.eax = I8K_SMM_SET_FAN;
 
-  speed = (speed < 0) ? 0 : ((speed > I8K_FAN_MAX) ? I8K_FAN_MAX : speed);
-  regs.ebx = (fan & 0xff) | (speed << 8);
+	speed = (speed < 0) ? 0 : ((speed > I8K_FAN_MAX) ? I8K_FAN_MAX : speed);
+	regs.ebx = (fan & 0xff) | (speed << 8);
 
-  return i8k_smm(&regs);
+	return i8k_smm(&regs);
 }
 
 int  SMIMonitor::i8k_set_fan_control_manual(int fan)
 {
-  INIT_REGS;
-  regs.eax = I8K_SMM_IO_DISABLE_FAN_CTL1;
-  regs.ebx = (fan & 0xff);
-  return i8k_smm(&regs);
+	INIT_REGS;
+	regs.eax = I8K_SMM_IO_DISABLE_FAN_CTL1;
+	regs.ebx = (fan & 0xff);
+	return i8k_smm(&regs);
 }
 
 int  SMIMonitor::i8k_set_fan_control_auto(int fan)
 {
-  INIT_REGS;
-  regs.eax = I8K_SMM_IO_ENABLE_FAN_CTL1;
-  regs.ebx = (fan & 0xff);
-  return i8k_smm(&regs);
+	INIT_REGS;
+	regs.eax = I8K_SMM_IO_ENABLE_FAN_CTL1;
+	regs.ebx = (fan & 0xff);
+	return i8k_smm(&regs);
 }
 
 void SMIMonitor::createShared() {
@@ -389,19 +390,23 @@ void SMIMonitor::updateSensors()
 	}
 	timerEventSource->cancelTimeout();
 	
-	//DBGLOG("sdell", "updateSensors");
-	
 	for (int i=0; i<fanCount; ++i)
 	{
-		int fan = state.fanInfo[i].index;
-		state.fanInfo[i].speed = i8k_get_fan_speed(fan);
+		int sensor = state.fanInfo[i].index;
+		int rc = i8k_get_fan_speed(sensor);
+		if (rc >= 0)
+			state.fanInfo[i].speed = rc;
+		IOSleep(50);
 	}
 
 	for (int i=0; i<tempCount; ++i)
 	{
-		int temp = state.tempInfo[i].index;
-		state.tempInfo[i].temp = i8k_get_temp(temp);
+		int sensor = state.tempInfo[i].index;
+		int rc = i8k_get_temp(sensor);
+		if (rc >= 0)
+			state.tempInfo[i].temp = rc;
+		IOSleep(50);
 	}
 	
-	timerEventSource->setTimeoutMS(800);
+	timerEventSource->setTimeoutMS(1000);
 }

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -396,7 +396,7 @@ void SMIMonitor::updateSensors()
 		int rc = i8k_get_fan_speed(sensor);
 		if (rc >= 0)
 			state.fanInfo[i].speed = rc;
-		IOSleep(50);
+		IOSleep(200);
 	}
 
 	for (int i=0; i<tempCount; ++i)
@@ -405,8 +405,8 @@ void SMIMonitor::updateSensors()
 		int rc = i8k_get_temp(sensor);
 		if (rc >= 0)
 			state.tempInfo[i].temp = rc;
-		IOSleep(50);
+		IOSleep(200);
 	}
 	
-	timerEventSource->setTimeoutMS(1000);
+	timerEventSource->setTimeoutMS(400);
 }

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -114,7 +114,7 @@ public:
 	static SMIMonitor *getShared() {
 		return instance;
 	}
-	
+
 	/**
 	 *  Probe battery manager
 	 *
@@ -131,7 +131,7 @@ public:
 	 *  Power-off handler
 	 */
 	void handlePowerOff();
-		
+
 	/**
 	 *  Power-on handler
 	 */
@@ -140,12 +140,12 @@ public:
 	 *  A lock to permit concurrent access
 	 */
 	IOLock *mainLock {nullptr};
-	
+
 	/**
 	 *  Main refreshed battery state containing battery information
 	 */
 	SMIState state {};
-	
+
 	/**
 	 *  Actual fan count
 	 */
@@ -172,7 +172,6 @@ private:
 	 */
 	static SMIMonitor *instance;
 
-	
 	/**
 	 *  Workloop used to poll SMI updates on timer basis
 	 */
@@ -182,31 +181,31 @@ private:
 	 *  Workloop timer event sources for refresh scheduling
 	 */
 	IOTimerEventSource *timerEventSource {nullptr};
-	
+
 	/**
 	 *  Find available fanssensors
 	 *
 	 *  @return true on sucess
 	 */
 	bool findFanSensors();
-	
+
 	/**
 	 *  Find available temperature sensors
 	 *
 	 *  @return true on sucess
 	 */
 	bool findTempSensors();
-	
+
 	/**
 	 *  Initial sensor update on startup
 	 */
 	bool initialUpdateSensors {false};
-		
+
 	/**
 	 *  Update sensors values, must be guarded by mainLock
 	 */
 	void updateSensors();
-	
+
 private:
 	int  i8k_smm(SMMRegisters *regs);
 	bool i8k_get_dell_sig_aux(int fn);
@@ -218,7 +217,7 @@ private:
 	int  i8k_get_fan_status(int fan);
 	int  i8k_get_fan_type(int fan);
 	int  i8k_get_fan_nominal_speed(int fan, int speed);
-	
+
 public:
 	int  i8k_set_fan(int fan, int speed);
 	int  i8k_set_fan_control_manual(int fan);

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -17,6 +17,7 @@
 #include "IOKit/acpi/IOACPIPlatformDevice.h"
 #include <IOKit/IOTimerEventSource.h>
 #include <i386/proc_reg.h>
+#include <Headers/kern_cpu.hpp>
 #include <Headers/kern_util.hpp>
 #include <Headers/kern_atomic.hpp>
 
@@ -96,11 +97,6 @@ typedef struct {
 } SMMRegisters;
 
 #define INIT_REGS               SMMRegisters regs = { 0, 0, 0, 0, 0, 0 }
-
-extern "C" {
-	extern void mp_rendezvous(void (*setup_func)(void *), void (*action_func)(void *), void (*teardown_func)(void *), void *arg);
-	int cpu_number(void);
-};
 
 class SMIMonitor : public OSObject
 {
@@ -207,12 +203,12 @@ private:
 	 *  Initial sensor update on startup
 	 */
 	bool initialUpdateSensors {false};
-	
+		
 	/**
 	 *  Update sensors values, must be guarded by mainLock
 	 */
 	void updateSensors();
-
+	
 private:
 	int  i8k_smm(SMMRegisters *regs);
 	bool i8k_get_dell_sig_aux(int fn);

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -96,8 +96,6 @@ typedef struct {
   unsigned int edi __attribute__ ((packed));
 } SMMRegisters;
 
-#define INIT_REGS               SMMRegisters regs = { 0, 0, 0, 0, 0, 0 }
-
 class SMIMonitor : public OSObject
 {
 	OSDeclareDefaultStructors(SMIMonitor)

--- a/Sensors/SMCLightSensor/Info.plist
+++ b/Sensors/SMCLightSensor/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MODULE_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(MODULE_VERSION)</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>SMCLightSensor</key>
@@ -37,7 +37,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2018 vit9696. All rights reserved.</string>
 	<key>OSBundleCompatibleVersion</key>
-        <string>1.0.0</string>
+	<string>1.0.0</string>
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>as.vit9696.Lilu</key>

--- a/VirtualSMC.xcodeproj/project.pbxproj
+++ b/VirtualSMC.xcodeproj/project.pbxproj
@@ -2904,11 +2904,11 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Lilu.kext/Contents/Resources/Library",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "";
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.1;
+				MODULE_VERSION = 1.1.6;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -2953,11 +2953,11 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Lilu.kext/Contents/Resources/Library",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "";
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.1;
+				MODULE_VERSION = 1.1.6;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -3003,11 +3003,11 @@
 					"$(PROJECT_DIR)/Lilu.kext/Contents/Resources/Library",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "";
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.1;
+				MODULE_VERSION = 1.1.6;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",

--- a/VirtualSMC.xcodeproj/project.pbxproj
+++ b/VirtualSMC.xcodeproj/project.pbxproj
@@ -2908,7 +2908,6 @@
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.1.6;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -2957,7 +2956,6 @@
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.1.6;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -3007,7 +3005,6 @@
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.1.6;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",

--- a/VirtualSMC.xcodeproj/project.pbxproj
+++ b/VirtualSMC.xcodeproj/project.pbxproj
@@ -2904,10 +2904,11 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Lilu.kext/Contents/Resources/Library",
 				);
+				MARKETING_VERSION = 1.0.1;
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.0;
+				MODULE_VERSION = 1.0.1;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -2952,10 +2953,11 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Lilu.kext/Contents/Resources/Library",
 				);
+				MARKETING_VERSION = 1.0.1;
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.0;
+				MODULE_VERSION = 1.0.1;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -3001,10 +3003,11 @@
 					"$(PROJECT_DIR)/Lilu.kext/Contents/Resources/Library",
 				);
 				LLVM_LTO = YES;
+				MARKETING_VERSION = 1.0.1;
 				MODULE_NAME = as.lvs1974.SMCDellSensors;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.0.0;
+				MODULE_VERSION = 1.0.1;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",


### PR DESCRIPTION
@tctien342 discovered issue with audio playing in Safari when SMCDellSensors is used.
I had to change method SMIMonitor::updateSensors(): do not read SMM continuously, use IOSleep between readings.
