### PR TITLE
Optimise smm access

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ VirtualSMC Changelog
 - Added battery supplement info, thx @zhen-zen
 - Fix audio lags in Safari caused by reading SMM in SMCDellSensors plugin
 - Fix module version for SMCDellSensors, SMCBatteryManager and SMCLightSensor
+- Optimised floating point sensor key reading with fewer arithmetic operations
 
 #### v1.1.5
 - Improved CHLC key value reporting

--- a/Sensors/SMCDellSensors/Info.plist
+++ b/Sensors/SMCDellSensors/Info.plist
@@ -55,10 +55,6 @@
 		<string>1.2.0</string>
 		<key>as.vit9696.VirtualSMC</key>
 		<string>1.0.0</string>
-		<key>com.apple.iokit.IOSMBusFamily</key>
-		<string>1.0.0</string>
-		<key>com.apple.iokit.IOACPIFamily</key>
-		<string>1.0.0d1</string>
 		<key>com.apple.kpi.bsd</key>
 		<string>12.0.0</string>
 		<key>com.apple.kpi.dsep</key>

--- a/Sensors/SMCDellSensors/KeyImplementations.cpp
+++ b/Sensors/SMCDellSensors/KeyImplementations.cpp
@@ -16,7 +16,7 @@ SMC_RESULT F0Ac::readAccess() {
 
 SMC_RESULT F0Mn::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].minSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
@@ -29,7 +29,7 @@ SMC_RESULT F0Mn::update(const SMC_DATA *src) {
 
 SMC_RESULT F0Mx::readAccess() {
 	auto value = SMIMonitor::getShared()->state.fanInfo[index].maxSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
@@ -54,7 +54,7 @@ SMC_RESULT F0Md::update(const SMC_DATA *src) {
 
 SMC_RESULT F0Tg::readAccess() {
 	auto value = SMIMonitor::getShared()->state.fanInfo[index].targetSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 

--- a/Sensors/SMCDellSensors/KeyImplementations.cpp
+++ b/Sensors/SMCDellSensors/KeyImplementations.cpp
@@ -8,32 +8,6 @@
 #include "KeyImplementations.hpp"
 #include "SMCDellSensors.hpp"
 
-static inline UInt16 swap_value(UInt16 value)
-{
-	return ((value & 0xff00) >> 8) | ((value & 0xff) << 8);
-}
-
-static inline UInt16 encode_fpe2(UInt16 value) {
-	return swap_value(value << 2);
-}
-
-static inline UInt16 decode_fpe2(UInt16 value) {
-	return (swap_value(value) >> 2);
-}
-
-static int setTargetSpeed(size_t index, UInt16 value) {
-	IOLockLock(SMIMonitor::getShared()->mainLock);
-	int status = 1;
-	int range = SMIMonitor::getShared()->state.fanInfo[index].maxSpeed - SMIMonitor::getShared()->state.fanInfo[index].minSpeed;
-	if (value > SMIMonitor::getShared()->state.fanInfo[index].minSpeed + range/2)
-		status = 2;
-	int rc = SMIMonitor::getShared()->i8k_set_fan(SMIMonitor::getShared()->state.fanInfo[index].index, status);
-	if (rc != 0)
-		SYSLOG("sdell", "Set target speed for fan %d to %d failed: %d", index, value, rc);
-	IOLockUnlock(SMIMonitor::getShared()->mainLock);
-	return rc;
-}
-
 SMC_RESULT F0Ac::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].speed;
 	//*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, val);
@@ -76,44 +50,20 @@ SMC_RESULT F0Md::readAccess() {
 }
 
 SMC_RESULT F0Md::update(const SMC_DATA *src) {
-	UInt16 val = src[0];
-	DBGLOG("sdell", "Set manual mode for fan %d to %d", index, val);
-	
-	int rc = 0;
-	if (val != (SMIMonitor::getShared()->fansStatus & (1 << index))>>index) {
-		IOLockLock(SMIMonitor::getShared()->mainLock);
-		rc = val ? SMIMonitor::getShared()->i8k_set_fan_control_manual(SMIMonitor::getShared()->state.fanInfo[index].index) :
-					SMIMonitor::getShared()->i8k_set_fan_control_auto(SMIMonitor::getShared()->state.fanInfo[index].index);
-		IOLockUnlock(SMIMonitor::getShared()->mainLock);
-	}
-	if (rc == 0) {
-		SMIMonitor::getShared()->fansStatus = val ? (SMIMonitor::getShared()->fansStatus | (1 << index)) :
-													(SMIMonitor::getShared()->fansStatus & ~(1 << index));
-		DBGLOG("sdell", "Set manual mode for fan %d to %d, fansStatus = 0x%02x", index, val, SMIMonitor::getShared()->fansStatus);
-	}
-	else
-		SYSLOG("sdell", "Set manual mode for fan %d to %d failed: %d", index, val, rc);
-	
+	SMIIdxKey::update(src);
+	SMIMonitor::getShared()->postSmcUpdate(KeyF0Md, index, src, sizeof(UInt8));
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Tg::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].targetSpeed;
-	//*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, val);
 	*reinterpret_cast<uint16_t *>(data) = encode_fpe2(value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Tg::update(const SMC_DATA *src) {
-	UInt16 value = decode_fpe2(*reinterpret_cast<const uint16_t *>(src));
-	DBGLOG("sdell", "Set target speed for fan %d to %d", index, value);
-	SMIMonitor::getShared()->state.fanInfo[index].targetSpeed = value;
-
-	if (SMIMonitor::getShared()->fansStatus & (1 << index))
-		setTargetSpeed(index, value);
-	else
-		SYSLOG("sdell", "Set target speed for fan %d to %d ignored since auto control is active", index, value);
-
+	SMIIdxKey::update(src);
+	SMIMonitor::getShared()->postSmcUpdate(KeyF0Tg, index, src, sizeof(UInt16));
 	return SmcSuccess;
 }
 
@@ -126,24 +76,8 @@ SMC_RESULT FS__::readAccess() {
 }
 
 SMC_RESULT FS__::update(const SMC_DATA *src) {
-	UInt16 val = (src[0] << 8) + src[1]; //big endian data
-	DBGLOG("sdell", "Set force fan mode to %d", val);
-	
-	IOLockLock(SMIMonitor::getShared()->mainLock);
-	int rc = 0;
-	for (int i = 0; i < SMIMonitor::getShared()->fanCount; i++) {
-		if ((val & (1 << i)) != (SMIMonitor::getShared()->fansStatus & (1 << i))) {
-			rc |= (val & (1 << i)) ? SMIMonitor::getShared()->i8k_set_fan_control_manual(SMIMonitor::getShared()->state.fanInfo[i].index) :
-									 SMIMonitor::getShared()->i8k_set_fan_control_auto(SMIMonitor::getShared()->state.fanInfo[i].index);
-		}
-	}
-
-	if (rc == 0)
-		SMIMonitor::getShared()->fansStatus = val;
-	else
-		SYSLOG("sdell", "Set force fan mode to %d failed: %d", val, rc);
-	IOLockUnlock(SMIMonitor::getShared()->mainLock);
-	
+	SMIKey::update(src);
+	SMIMonitor::getShared()->postSmcUpdate(KeyFS__, -1, src, sizeof(UInt16));
 	return SmcSuccess;
 }
 

--- a/Sensors/SMCDellSensors/KeyImplementations.cpp
+++ b/Sensors/SMCDellSensors/KeyImplementations.cpp
@@ -9,39 +9,39 @@
 #include "SMCDellSensors.hpp"
 
 SMC_RESULT F0Ac::readAccess() {
-	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].speed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
+	auto value = SMIMonitor::getShared()->state.fanInfo[index].speed;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mn::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].minSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mn::update(const SMC_DATA *src) {
 	SMIIdxKey::update(src);
-	UInt16 value = VirtualSMCAPI::decodeIntSp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
+	auto value = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
 	SYSLOG("sdell", "Set new minimum speed for fan %d to %d", index, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mx::readAccess() {
-	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].maxSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
+	auto value = SMIMonitor::getShared()->state.fanInfo[index].maxSpeed;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mx::update(const SMC_DATA *src) {
 	SMIIdxKey::update(src);
-	UInt16 value = VirtualSMCAPI::decodeIntSp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
+	auto value = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
 	SYSLOG("sdell", "Set new maximum speed for fan %d to %d", index, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Md::readAccess() {
-	UInt16 val = (SMIMonitor::getShared()->fansStatus & (1 << index)) >> index;
+	auto val = (SMIMonitor::getShared()->fansStatus & (1 << index)) >> index;
 	*reinterpret_cast<uint8_t *>(data) = val;
 	return SmcSuccess;
 }
@@ -53,8 +53,8 @@ SMC_RESULT F0Md::update(const SMC_DATA *src) {
 }
 
 SMC_RESULT F0Tg::readAccess() {
-	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].targetSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
+	auto value = SMIMonitor::getShared()->state.fanInfo[index].targetSpeed;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
@@ -79,37 +79,37 @@ SMC_RESULT FS__::update(const SMC_DATA *src) {
 }
 
 SMC_RESULT TC0P::readAccess() {
-	double val = SMIMonitor::getShared()->state.tempInfo[index].temp;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(SmcKeyTypeSp78, val);
+	auto val = SMIMonitor::getShared()->state.tempInfo[index].temp;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeSp78, val);
 	return SmcSuccess;
 }
 
 SMC_RESULT TG0P::readAccess() {
-	double val = SMIMonitor::getShared()->state.tempInfo[index].temp;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(SmcKeyTypeSp78, val);
+	auto val = SMIMonitor::getShared()->state.tempInfo[index].temp;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeSp78, val);
 	return SmcSuccess;
 }
 
 SMC_RESULT Tm0P::readAccess() {
-	double val = SMIMonitor::getShared()->state.tempInfo[index].temp;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(SmcKeyTypeSp78, val);
+	auto val = SMIMonitor::getShared()->state.tempInfo[index].temp;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeSp78, val);
 	return SmcSuccess;
 }
 
 SMC_RESULT TN0P::readAccess() {
-	double val = SMIMonitor::getShared()->state.tempInfo[index].temp;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(SmcKeyTypeSp78, val);
+	auto val = SMIMonitor::getShared()->state.tempInfo[index].temp;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeSp78, val);
 	return SmcSuccess;
 }
 
 SMC_RESULT TA0P::readAccess() {
-	double val = SMIMonitor::getShared()->state.tempInfo[index].temp;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(SmcKeyTypeSp78, val);
+	auto val = SMIMonitor::getShared()->state.tempInfo[index].temp;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeSp78, val);
 	return SmcSuccess;
 }
 
 SMC_RESULT TW0P::readAccess() {
-	double val = SMIMonitor::getShared()->state.tempInfo[index].temp;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(SmcKeyTypeSp78, val);
+	auto val = SMIMonitor::getShared()->state.tempInfo[index].temp;
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeSp78, val);
 	return SmcSuccess;
 }

--- a/Sensors/SMCDellSensors/KeyImplementations.cpp
+++ b/Sensors/SMCDellSensors/KeyImplementations.cpp
@@ -10,35 +10,32 @@
 
 SMC_RESULT F0Ac::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].speed;
-	//*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, val);
-	*reinterpret_cast<uint16_t *>(data) = encode_fpe2(value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mn::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].minSpeed;
-	//*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, val);
-	*reinterpret_cast<uint16_t *>(data) = encode_fpe2(value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mn::update(const SMC_DATA *src) {
 	SMIIdxKey::update(src);
-	UInt16 value = decode_fpe2(*reinterpret_cast<const uint16_t *>(src));
+	UInt16 value = VirtualSMCAPI::decodeFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
 	SYSLOG("sdell", "Set new minimum speed for fan %d to %d", index, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mx::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].maxSpeed;
-	//*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, val);
-	*reinterpret_cast<uint16_t *>(data) = encode_fpe2(value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mx::update(const SMC_DATA *src) {
 	SMIIdxKey::update(src);
-	UInt16 value = decode_fpe2(*reinterpret_cast<const uint16_t *>(src));
+	UInt16 value = VirtualSMCAPI::decodeFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
 	SYSLOG("sdell", "Set new maximum speed for fan %d to %d", index, value);
 	return SmcSuccess;
 }
@@ -57,7 +54,7 @@ SMC_RESULT F0Md::update(const SMC_DATA *src) {
 
 SMC_RESULT F0Tg::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].targetSpeed;
-	*reinterpret_cast<uint16_t *>(data) = encode_fpe2(value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 

--- a/Sensors/SMCDellSensors/KeyImplementations.cpp
+++ b/Sensors/SMCDellSensors/KeyImplementations.cpp
@@ -10,32 +10,32 @@
 
 SMC_RESULT F0Ac::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].speed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mn::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].minSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mn::update(const SMC_DATA *src) {
 	SMIIdxKey::update(src);
-	UInt16 value = VirtualSMCAPI::decodeFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
+	UInt16 value = VirtualSMCAPI::decodeIntSp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
 	SYSLOG("sdell", "Set new minimum speed for fan %d to %d", index, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mx::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].maxSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 
 SMC_RESULT F0Mx::update(const SMC_DATA *src) {
 	SMIIdxKey::update(src);
-	UInt16 value = VirtualSMCAPI::decodeFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
+	UInt16 value = VirtualSMCAPI::decodeIntSp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));
 	SYSLOG("sdell", "Set new maximum speed for fan %d to %d", index, value);
 	return SmcSuccess;
 }
@@ -54,7 +54,7 @@ SMC_RESULT F0Md::update(const SMC_DATA *src) {
 
 SMC_RESULT F0Tg::readAccess() {
 	UInt16 value = SMIMonitor::getShared()->state.fanInfo[index].targetSpeed;
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, value);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(SmcKeyTypeFpe2, value);
 	return SmcSuccess;
 }
 

--- a/Sensors/SMCDellSensors/KeyImplementations.hpp
+++ b/Sensors/SMCDellSensors/KeyImplementations.hpp
@@ -37,4 +37,5 @@ class TN0P : public SMIIdxKey { using SMIIdxKey::SMIIdxKey; protected: SMC_RESUL
 class TA0P : public SMIIdxKey { using SMIIdxKey::SMIIdxKey; protected: SMC_RESULT readAccess() override; };
 class TW0P : public SMIIdxKey { using SMIIdxKey::SMIIdxKey; protected: SMC_RESULT readAccess() override; };
 
+
 #endif /* KeyImplementations_hpp */

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -597,7 +597,7 @@ void SMIMonitor::hanldeManualControlUpdate(size_t index, UInt8 *data)
 
 void SMIMonitor::hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data)
 {
-	UInt16 value = VirtualSMCAPI::decodeIntSp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(data));
+	auto value = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(data));
 	DBGLOG("sdell", "Set target speed for fan %d to %d", index, value);
 	state.fanInfo[index].targetSpeed = value;
 
@@ -615,7 +615,7 @@ void SMIMonitor::hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data)
 
 void SMIMonitor::handleManualForceFanControlUpdate(UInt8 *data)
 {
-	UInt16 val = (data[0] << 8) + data[1]; //big endian data
+	auto val = (data[0] << 8) + data[1]; //big endian data
 	DBGLOG("sdell", "Set force fan mode to %d", val);
 
 	int rc = 0;

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -464,8 +464,6 @@ void SMIMonitor::staticUpdateThreadEntry(thread_call_param_t param0, thread_call
 		return;
 	}
 
-	IOLockLock(that->mainLock);
-
 	bool success = true;
 	while (1) {
 			
@@ -503,6 +501,7 @@ void SMIMonitor::staticUpdateThreadEntry(thread_call_param_t param0, thread_call
 		break;
 	}
 	
+	IOLockLock(that->mainLock);
 	that->initialized = success ? KERN_SUCCESS : KERN_FAILURE;
 	IOLockWakeup(that->mainLock, &that->initialized, true);
 	IOLockUnlock(that->mainLock);

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -257,8 +257,9 @@ void SMIMonitor::createShared() {
 }
 
 bool SMIMonitor::probe() {
-	
+
 	bool success = true;
+
 	
 	while (!updateCall) {
 		updateCall = thread_call_allocate(staticUpdateThreadEntry, this);
@@ -588,7 +589,7 @@ void SMIMonitor::hanldeManualControlUpdate(size_t index, UInt8 *data)
 
 void SMIMonitor::hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data)
 {
-	UInt16 value = decode_fpe2(*reinterpret_cast<const UInt16 *>(data));
+	UInt16 value = VirtualSMCAPI::decodeFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(data));
 	DBGLOG("sdell", "Set target speed for fan %d to %d", index, value);
 	state.fanInfo[index].targetSpeed = value;
 

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -513,8 +513,7 @@ void SMIMonitor::updateSensorsLoop() {
 			int rc = i8k_get_temp(sensor);
 			if (rc >= 0)
 				state.tempInfo[i].temp = rc;
-			if (i+1 < tempCount)
-				handleSmcUpdatesInIdle(10);
+			handleSmcUpdatesInIdle(10);
 		}
 		
 		handleSmcUpdatesInIdle(25);

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -9,6 +9,11 @@
  */
 
 #include "SMIMonitor.hpp"
+#include <Headers/kern_cpu.hpp>
+
+extern "C" {
+#include <Library/osfmk/i386/pmCPU.h>
+}
 
 SMIMonitor *SMIMonitor::instance = nullptr;
 
@@ -17,6 +22,12 @@ OSDefineMetaClassAndStructors(SMIMonitor, OSObject)
 static int smm(SMMRegisters *regs) {
 	int rc;
 	int eax = regs->eax;  //input value
+	
+	bool enable = ml_set_interrupts_enabled(FALSE);
+	auto cpu_n = cpu_number();
+	if (cpu_n != 0) {
+		DBGLOG("sdell", "smm is called in context of CPU %d", cpu_n);
+	}
 
 #if __LP64__
 	asm volatile("pushq %%rax\n\t"
@@ -72,6 +83,8 @@ static int smm(SMMRegisters *regs) {
 			: "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #endif
 
+	ml_set_interrupts_enabled(enable);
+
 	if ((rc != 0) || ((regs->eax & 0xffff) == 0xffff) || (regs->eax == eax)) {
 		return -1;
 	}
@@ -80,14 +93,7 @@ static int smm(SMMRegisters *regs) {
 }
 
 int SMIMonitor::i8k_smm(SMMRegisters *regs) {
-	static int gRc;
-	gRc = -1;
-	mp_rendezvous_no_intrs([](void *arg) {
-		if (cpu_number() == 0) { /* SMM requires CPU 0 */
-			gRc = smm(static_cast<SMMRegisters *>(arg));
-		}
-	}, regs);
-	return gRc;
+	return smm(regs);
 }
 
 /*
@@ -145,7 +151,7 @@ bool SMIMonitor::i8k_get_dell_sig_aux(int fn) {
 			(regs.edx == 0x44454C4C /*DELL*/));
 }
 
-bool SMIMonitor::i8k_get_dell_signature(void) {
+bool SMIMonitor::i8k_get_dell_signature() {
 	return (i8k_get_dell_sig_aux(I8K_SMM_GET_DELL_SIG1) ||
 		    i8k_get_dell_sig_aux(I8K_SMM_GET_DELL_SIG2));
 }
@@ -246,77 +252,141 @@ void SMIMonitor::createShared() {
 	instance->mainLock = IOLockAlloc();
 	if (!instance->mainLock)
 		PANIC("sdell", "failed to allocate smi monitor main lock");
+	instance->queueLock = IOSimpleLockAlloc();
+	if (!instance->queueLock)
+		PANIC("sdell", "failed to allocate simple lock");
+	// Reserve SMC updates slots
+	if (!instance->storedSmcUpdates.reserve(MaxActiveSmcUpdates))
+		PANIC("sdell", "failed to reserve SMC updates slots");
 }
 
 bool SMIMonitor::probe() {
-	IOLockLock(mainLock);
-	if (!i8k_get_dell_signature()) {
-		SYSLOG("sdell", "Unable to get Dell SMM signature!");
-		IOLockUnlock(mainLock);
-		return false;
-	}
 	
 	bool success = true;
 	
-	if (!workloop) {
-		DBGLOG("sdell", "probing smi monitor");
-
-		workloop = IOWorkLoop::workLoop();
-		timerEventSource = IOTimerEventSource::timerEventSource(this, [](OSObject *object, IOTimerEventSource *sender) {
-			auto bm = OSDynamicCast(SMIMonitor, object);
-			if (bm) {
-				IOLockLock(bm->mainLock);
-				bm->updateSensors();
-				IOLockUnlock(bm->mainLock);
-			}
-		});
-		if (!timerEventSource || !workloop) {
-			SYSLOG("sdell", "failed to create workloop or timer event source");
+	while (!updateCall) {
+		updateCall = thread_call_allocate(staticUpdateThreadEntry, this);
+		if (!updateCall) {
+			DBGLOG("sdell", "Update thread cannot be created");
 			success = false;
-		}
-
-		if (success && workloop->addEventSource(timerEventSource) != kIOReturnSuccess) {
-			SYSLOG("sdell", "failed to add timer event source");
-			success = false;
+			break;
 		}
 		
-		// timerEventSource must exist before adding ACPI notification handler
-		if (success && (!findFanSensors() || !findTempSensors())) {
-			SYSLOG("sdell", "failed to find fans or temp sensors!");
-			success = false;
-		}
+		IOLockLock(mainLock);
+		thread_call_enter(updateCall);
 		
+		while (initialized == -1) {
+			IOLockSleep(mainLock, &initialized, THREAD_UNINT);
+		}
+		IOLockUnlock(mainLock);
+
+		if (initialized != KERN_SUCCESS) {
+			success = false;
+			break;
+		}
+
 		DBGLOG("sdell", "found %u fan sensors and %u temp sensors", fanCount, tempCount);
+		break;
+	}
 
-		if (!success) {
-			OSSafeReleaseNULL(workloop);
-			OSSafeReleaseNULL(timerEventSource);
+	if (!success) {
+		if (updateCall) {
+			while (!thread_call_free(updateCall))
+				thread_call_cancel(updateCall);
+			updateCall = nullptr;
 		}
 	}
 	
 	DBGLOG("sdell", "Based on I8kfan project and adopted to VirtualSMC plugin");
 
-	IOLockUnlock(mainLock);
 	return success;
 }
 
 void SMIMonitor::start() {
-	IOLockLock(mainLock);
-	if (!initialUpdateSensors) {
-		for (int i=0; i<fanCount; ++i)
-			i8k_set_fan_control_auto(state.fanInfo[i].index); // force automatic control
-		updateSensors();
-		initialUpdateSensors = true;
-	}
-	IOLockUnlock(mainLock);
 }
 
 void SMIMonitor::handlePowerOff() {
-	timerEventSource->disable();
 }
 
 void SMIMonitor::handlePowerOn() {
-	timerEventSource->enable();
+}
+
+bool SMIMonitor::postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint32_t dataSize)
+{
+	IOSimpleLockLock(queueLock);
+
+	bool success = false;
+	while (1) {
+	
+		if (dataSize > sizeof(StoredSmcUpdate::data)) {
+			SYSLOG("sdell", "postRequest dataSize overflow %u", dataSize);
+			break;
+		}
+
+		for (size_t i = 0; i < storedSmcUpdates.size() && !success; i++) {
+			auto &si = storedSmcUpdates[i];
+			if (si.key == key && si.index == index) {
+				si.size = dataSize;
+				if (dataSize > 0)
+					lilu_os_memcpy(si.data, data, dataSize);
+				success = true;
+				break;
+			}
+		}
+		
+		if (success) break;
+
+		if (storedSmcUpdates.size() == MaxActiveSmcUpdates) {
+			SYSLOG("sdell", "postRequest reserve overflow");
+			break;
+		}
+
+		StoredSmcUpdate si {key, index, dataSize};
+		if (dataSize > 0)
+			lilu_os_memcpy(si.data, data, dataSize);
+		if (storedSmcUpdates.push_back(si)) {
+			success = true;
+			break;
+		}
+		break;
+	}
+	IOSimpleLockUnlock(queueLock);
+	
+	if (!success)
+		SYSLOG("sdell", "unable to store smc update");
+
+	return success;
+}
+
+IOReturn SMIMonitor::bindCurrentThreadToCpu0()
+{
+	// Obtain power management callbacks
+	pmCallBacks_t callbacks {};
+	pmKextRegister(PM_DISPATCH_VERSION, nullptr, &callbacks);
+	
+	if (!callbacks.LCPUtoProcessor) {
+		SYSLOG("sdell", "failed to obtain LCPUtoProcessor");
+		return KERN_FAILURE;
+	}
+	
+	if (!callbacks.ThreadBind) {
+		SYSLOG("sdell", "failed to obtain ThreadBind");
+		return KERN_FAILURE;
+	}
+
+	auto enable = ml_set_interrupts_enabled(FALSE);
+	
+	auto processor = callbacks.LCPUtoProcessor(0);
+	if (processor == nullptr) {
+		ml_set_interrupts_enabled(enable);
+		SYSLOG("sdell", "failed to call LCPUtoProcessor with cpu 0");
+		return KERN_FAILURE;
+	}
+	callbacks.ThreadBind(processor);
+
+	ml_set_interrupts_enabled(enable);
+	
+	return KERN_SUCCESS;
 }
 
 bool SMIMonitor::findFanSensors() {
@@ -367,30 +437,171 @@ bool SMIMonitor::findTempSensors() {
 	return tempCount > 0;
 }
 
-void SMIMonitor::updateSensors() {
-	if (timerEventSource == nullptr) {
-		DBGLOG("sdell", "WTF timerEventSource is null");
+void SMIMonitor::staticUpdateThreadEntry(thread_call_param_t param0, thread_call_param_t param1)
+{
+	auto *that = OSDynamicCast(SMIMonitor, reinterpret_cast<OSObject*>(param0));
+	if (!that) {
+		SYSLOG("sdell", "Failed to get pointer to SMIMonitor");
 		return;
 	}
-	timerEventSource->cancelTimeout();
+
+	IOLockLock(that->mainLock);
+
+	bool success = true;
+	while (1) {
+			
+		IOReturn result = bindCurrentThreadToCpu0();
+		if (result != KERN_SUCCESS) {
+			success = false;
+			break;
+		}
+		
+		IOSleep(500);
+		
+		auto enable = ml_set_interrupts_enabled(FALSE);
+		auto cpu_n = cpu_number();
+		ml_set_interrupts_enabled(enable);
+		
+		if (cpu_n != 0) {
+			DBGLOG("sdell", "staticUpdateThreadEntry is called in context CPU %d", cpu_n);
+			success = false;
+			break;
+		}
+		
+		if (!that->i8k_get_dell_signature()) {
+			SYSLOG("sdell", "Unable to get Dell SMM signature!");
+			success = false;
+			break;
+		}
+
+		if (!that->findFanSensors() || !that->findTempSensors()) {
+			SYSLOG("sdell", "failed to find fans or temp sensors!");
+			success = false;
+			break;
+		}
+		
+		break;
+	}
+	
+	that->initialized = success ? KERN_SUCCESS : KERN_FAILURE;
+	IOLockWakeup(that->mainLock, &that->initialized, true);
+	IOLockUnlock(that->mainLock);
+	
+	if (success)
+		that->updateSensorsLoop();
+}
+
+void SMIMonitor::updateSensorsLoop() {
 	
 	for (int i=0; i<fanCount; ++i)
+		i8k_set_fan_control_auto(state.fanInfo[i].index); // force automatic control
+		
+	while (1) {
+		
+		for (int i=0; i<fanCount; ++i)
+		{
+			int sensor = state.fanInfo[i].index;
+			int rc = i8k_get_fan_speed(sensor);
+			if (rc >= 0)
+				state.fanInfo[i].speed = rc;
+			handleSmcUpdatesInIdle(10);
+		}
+
+		for (int i=0; i<tempCount; ++i)
+		{
+			int sensor = state.tempInfo[i].index;
+			int rc = i8k_get_temp(sensor);
+			if (rc >= 0)
+				state.tempInfo[i].temp = rc;
+			if (i+1 < tempCount)
+				handleSmcUpdatesInIdle(10);
+		}
+		
+		handleSmcUpdatesInIdle(25);
+	}
+}
+
+void SMIMonitor::handleSmcUpdatesInIdle(int idle_loop_count)
+{
+	for (int i=0; i<idle_loop_count; ++i)
 	{
-		int sensor = state.fanInfo[i].index;
-		int rc = i8k_get_fan_speed(sensor);
-		if (rc >= 0)
-			state.fanInfo[i].speed = rc;
-		IOSleep(200);
+		IOSimpleLockLock(queueLock);
+		if (storedSmcUpdates.size() > 0) {
+			StoredSmcUpdate update = storedSmcUpdates[0];
+			storedSmcUpdates.erase(0, false);
+			IOSimpleLockUnlock(queueLock);
+			
+			switch (update.key) {
+				case KeyF0Md:
+					hanldeManualControlUpdate(update.index, update.data);
+					break;
+				case KeyF0Tg:
+					hanldeManualTargetSpeedUpdate(update.index, update.data);
+					break;
+				case KeyFS__:
+					handleManualForceFanControlUpdate(update.data);
+					break;
+			}
+		}
+		else {
+			IOSimpleLockUnlock(queueLock);
+		}
+
+		IOSleep(20);
+	}
+}
+
+void SMIMonitor::hanldeManualControlUpdate(size_t index, UInt8 *data)
+{
+	UInt16 val = data[0];
+	DBGLOG("sdell", "Set manual mode for fan %d to %d", index, val);
+
+	int rc = 0;
+	if (val != (fansStatus & (1 << index))>>index) {
+		rc = val ? i8k_set_fan_control_manual(state.fanInfo[index].index) :
+					i8k_set_fan_control_auto(state.fanInfo[index].index);
+	}
+	if (rc == 0) {
+		fansStatus = val ? (fansStatus | (1 << index)) : (fansStatus & ~(1 << index));
+		DBGLOG("sdell", "Set manual mode for fan %d to %d, fansStatus = 0x%02x", index, val, fansStatus);
+	}
+	else
+		SYSLOG("sdell", "Set manual mode for fan %d to %d failed: %d", index, val, rc);
+}
+
+void SMIMonitor::hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data)
+{
+	UInt16 value = decode_fpe2(*reinterpret_cast<const UInt16 *>(data));
+	DBGLOG("sdell", "Set target speed for fan %d to %d", index, value);
+	state.fanInfo[index].targetSpeed = value;
+
+	if (fansStatus & (1 << index)) {
+		int status = 1;
+		int range = state.fanInfo[index].maxSpeed - state.fanInfo[index].minSpeed;
+		if (value > state.fanInfo[index].minSpeed + range/2)
+			status = 2;
+		int rc = i8k_set_fan(state.fanInfo[index].index, status);
+		if (rc != 0)
+			SYSLOG("sdell", "Set target speed for fan %d to %d failed: %d", index, value, rc);	}
+	else
+		SYSLOG("sdell", "Set target speed for fan %d to %d ignored since auto control is active", index, value);
+}
+
+void SMIMonitor::handleManualForceFanControlUpdate(UInt8 *data)
+{
+	UInt16 val = (data[0] << 8) + data[1]; //big endian data
+	DBGLOG("sdell", "Set force fan mode to %d", val);
+
+	int rc = 0;
+	for (int i = 0; i < fanCount; i++) {
+		if ((val & (1 << i)) != (fansStatus & (1 << i))) {
+			rc |= (val & (1 << i)) ? i8k_set_fan_control_manual(state.fanInfo[i].index) :
+									 i8k_set_fan_control_auto(state.fanInfo[i].index);
+		}
 	}
 
-	for (int i=0; i<tempCount; ++i)
-	{
-		int sensor = state.tempInfo[i].index;
-		int rc = i8k_get_temp(sensor);
-		if (rc >= 0)
-			state.tempInfo[i].temp = rc;
-		IOSleep(200);
-	}
-	
-	timerEventSource->setTimeoutMS(400);
+	if (rc == 0)
+		fansStatus = val;
+	else
+		SYSLOG("sdell", "Set force fan mode to %d failed: %d", val, rc);
 }

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -203,6 +203,11 @@ private:
 	IOSimpleLock *queueLock {nullptr};
 	
 	/**
+	 *  A simple lock to disable preemtion
+	 */
+	IOSimpleLock *preemptionLock {nullptr};
+	
+	/**
 	 *  handle of thread used to poll SMI updates
 	 */
 	thread_call_t updateCall {nullptr};

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -216,6 +216,11 @@ private:
 	 *  variable-event, keeps thread initialization result (0 or error code)
 	 */
 	_Atomic(int) initialized = -1;
+	
+	/**
+	 *  Awake flag
+	 */
+	_Atomic(bool) awake = true;
 
 	/**
 	 *  Stored events for writing to SMM (event queue)

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -203,7 +203,7 @@ private:
 	IOSimpleLock *queueLock {nullptr};
 	
 	/**
-	 *  A simple lock to disable preemtion
+	 *  A simple lock to disable preemption
 	 */
 	IOSimpleLock *preemptionLock {nullptr};
 	

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -288,17 +288,12 @@ static constexpr SMC_KEY KeyF0Md = SMC_MAKE_IDENTIFIER('F',0,'M','d');
 static constexpr SMC_KEY KeyF0Tg = SMC_MAKE_IDENTIFIER('F',0,'T','g');
 static constexpr SMC_KEY KeyFS__ = SMC_MAKE_IDENTIFIER('F','S','!',' ');
 
-inline UInt16 swap_value(UInt16 value)
-{
-	return ((value & 0xff00) >> 8) | ((value & 0xff) << 8);
-}
-
 inline UInt16 encode_fpe2(UInt16 value) {
-	return swap_value(value << 2);
+	return OSSwapInt16(value << 2);
 }
 
 inline UInt16 decode_fpe2(UInt16 value) {
-	return (swap_value(value) >> 2);
+	return (OSSwapInt16(value) >> 2);
 }
 
 #endif /* SMIMonitor_hpp */

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -223,9 +223,9 @@ private:
 	static constexpr size_t MaxActiveSmcUpdates {40};
 	
 	/**
-	 *  Bind Workloop thread to CPU 0
+	 *  Bind working thread to CPU 0
 	 */
-	static IOReturn bindCurrentThreadToCpu0();
+	IOReturn bindCurrentThreadToCpu0();
 	
 	/**
 	 *  Find available fanssensors

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -85,12 +85,12 @@
 #define I8K_FN_SHIFT			8
 
 struct SMMRegisters {
-  unsigned int eax;
-  unsigned int ebx __attribute__ ((packed));
-  unsigned int ecx __attribute__ ((packed));
-  unsigned int edx __attribute__ ((packed));
-  unsigned int esi __attribute__ ((packed));
-  unsigned int edi __attribute__ ((packed));
+	unsigned int eax;
+	unsigned int ebx;
+	unsigned int ecx;
+	unsigned int edx;
+	unsigned int esi;
+	unsigned int edi;
 };
 
 struct StoredSmcUpdate {
@@ -155,7 +155,7 @@ public:
 	 *  Power-on handler
 	 */
 	void handlePowerOn();
-	
+
 	/**
 	 *  Post request
 	 */
@@ -169,7 +169,7 @@ public:
 	/**
 	 *  Actual fan control status
 	 */
-	_Atomic(UInt16)	fansStatus = 0;
+	_Atomic(uint16_t)	fansStatus = 0;
 
 	/**
 	 *  Actual fan count
@@ -191,7 +191,7 @@ private:
 	 *  The only allowed battery manager instance
 	 */
 	static SMIMonitor *instance;
-	
+
 	/**
 	 *  A lock to permit concurrent access
 	 */
@@ -201,37 +201,37 @@ private:
 	 *  A simple lock to permit concurrent access to queue
 	 */
 	IOSimpleLock *queueLock {nullptr};
-	
+
 	/**
 	 *  A simple lock to disable preemption
 	 */
 	IOSimpleLock *preemptionLock {nullptr};
-	
+
 	/**
 	 *  handle of thread used to poll SMI updates
 	 */
 	thread_call_t updateCall {nullptr};
-	
+
 	/**
 	 *  variable-event, keeps thread initialization result (0 or error code)
 	 */
 	_Atomic(int) initialized = -1;
-	
+
 	/**
 	 *  Stored events for writing to SMM (event queue)
 	 */
 	evector<StoredSmcUpdate&> storedSmcUpdates;
-	
+
 	/**
 	 *  Smc updates may happen which have to be handled in thread binded to CPU 0
 	 */
 	static constexpr size_t MaxActiveSmcUpdates {40};
-	
+
 	/**
 	 *  Bind working thread to CPU 0
 	 */
 	IOReturn bindCurrentThreadToCpu0();
-	
+
 	/**
 	 *  Find available fanssensors
 	 *
@@ -245,7 +245,7 @@ private:
 	 *  @return true on sucess
 	 */
 	bool findTempSensors();
-	
+
 	/**
 	 *  static Thread Entry method
 	 *
@@ -253,24 +253,24 @@ private:
 	 *  @param param1 unused
 	 */
 	static void staticUpdateThreadEntry(thread_call_param_t param0, thread_call_param_t param1);
-	
+
 	/**
 	 *  Update sensors values
 	 */
 	void updateSensorsLoop();
-	
+
 	/*
 	 * Handle SMC updates in idle
 	 */
 	void handleSmcUpdatesInIdle(int idle_loop_count);
-	
+
 	/**
 	 *  SMC update handlers
 	 */
 	void hanldeManualControlUpdate(size_t index, UInt8 *data);
 	void hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data);
 	void handleManualForceFanControlUpdate(UInt8 *data);
-	
+
 private:
 	int  i8k_smm(SMMRegisters *regs);
 	bool i8k_get_dell_sig_aux(int fn);
@@ -292,13 +292,5 @@ private:
 static constexpr SMC_KEY KeyF0Md = SMC_MAKE_IDENTIFIER('F',0,'M','d');
 static constexpr SMC_KEY KeyF0Tg = SMC_MAKE_IDENTIFIER('F',0,'T','g');
 static constexpr SMC_KEY KeyFS__ = SMC_MAKE_IDENTIFIER('F','S','!',' ');
-
-inline UInt16 encode_fpe2(UInt16 value) {
-	return OSSwapInt16(value << 2);
-}
-
-inline UInt16 decode_fpe2(UInt16 value) {
-	return (OSSwapInt16(value) >> 2);
-}
 
 #endif /* SMIMonitor_hpp */

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -13,15 +13,12 @@
 #ifndef SMIMonitor_hpp
 #define SMIMonitor_hpp
 
-#include <IOKit/IOService.h>
-#include "IOKit/acpi/IOACPIPlatformDevice.h"
-#include <IOKit/IOTimerEventSource.h>
 #include <i386/proc_reg.h>
-#include <Headers/kern_cpu.hpp>
-#include <Headers/kern_util.hpp>
 #include <Headers/kern_atomic.hpp>
+#include <VirtualSMCSDK/kern_vsmcapi.hpp>
 
 #include "SMIState.hpp"
+
 
 #define I8K_SMM_FN_STATUS					0x0025
 #define I8K_SMM_POWER_STATUS				0x0069	/* 0x85*/ /* not confirmed*/
@@ -87,14 +84,36 @@
 #define I8K_FN_MASK				0x07
 #define I8K_FN_SHIFT			8
 
-typedef struct {
+struct SMMRegisters {
   unsigned int eax;
   unsigned int ebx __attribute__ ((packed));
   unsigned int ecx __attribute__ ((packed));
   unsigned int edx __attribute__ ((packed));
   unsigned int esi __attribute__ ((packed));
   unsigned int edi __attribute__ ((packed));
-} SMMRegisters;
+};
+
+struct StoredSmcUpdate {
+	/**
+	 *  SMC key
+	 */
+	SMC_KEY key {};
+
+	/**
+	 *  SMC key index (if applicable)
+	 */
+	size_t index {};
+	
+	/**
+	 *  SMC data size
+	 */
+	uint32_t size {};
+
+	/**
+	 *  SMC data
+	 */
+	uint8_t data[SMC_MAX_LOG_SIZE] {};
+};
 
 class SMIMonitor : public OSObject
 {
@@ -136,15 +155,21 @@ public:
 	 *  Power-on handler
 	 */
 	void handlePowerOn();
+	
 	/**
-	 *  A lock to permit concurrent access
+	 *  Post request
 	 */
-	IOLock *mainLock {nullptr};
+	bool postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint32_t dataSize);
 
 	/**
 	 *  Main refreshed battery state containing battery information
 	 */
 	SMIState state {};
+
+	/**
+	 *  Actual fan control status
+	 */
+	_Atomic(UInt16)	fansStatus = 0;
 
 	/**
 	 *  Actual fan count
@@ -157,31 +182,51 @@ public:
 	_Atomic(uint32_t) tempCount = 0;
 
 	/**
-	 *  Actual fan control status
-	 */
-	_Atomic(UInt16)	fansStatus = 0;
-
-	/**
 	 *  Fan multiplier
 	 */
 	_Atomic(int) fanMult = 1;
-
+	
 private:
 	/**
 	 *  The only allowed battery manager instance
 	 */
 	static SMIMonitor *instance;
+	
+	/**
+	 *  A lock to permit concurrent access
+	 */
+	IOLock *mainLock {nullptr};
 
 	/**
-	 *  Workloop used to poll SMI updates on timer basis
+	 *  A simple lock to permit concurrent access to queue
 	 */
-	IOWorkLoop *workloop {nullptr};
-
+	IOSimpleLock *queueLock {nullptr};
+	
 	/**
-	 *  Workloop timer event sources for refresh scheduling
+	 *  handle of thread used to poll SMI updates
 	 */
-	IOTimerEventSource *timerEventSource {nullptr};
-
+	thread_call_t updateCall {nullptr};
+	
+	/**
+	 *  variable-event, keeps thread initialization result (0 or error code)
+	 */
+	_Atomic(int) initialized = -1;
+	
+	/**
+	 *  Stored events for writing to SMM (event queue)
+	 */
+	evector<StoredSmcUpdate&> storedSmcUpdates;
+	
+	/**
+	 *  Smc updates may happen which have to be handled in thread binded to CPU 0
+	 */
+	static constexpr size_t MaxActiveSmcUpdates {40};
+	
+	/**
+	 *  Bind Workloop thread to CPU 0
+	 */
+	static IOReturn bindCurrentThreadToCpu0();
+	
 	/**
 	 *  Find available fanssensors
 	 *
@@ -195,33 +240,65 @@ private:
 	 *  @return true on sucess
 	 */
 	bool findTempSensors();
-
+	
 	/**
-	 *  Initial sensor update on startup
+	 *  static Thread Entry method
+	 *
+	 *  @param param0 unused
+	 *  @param param1 unused
 	 */
-	bool initialUpdateSensors {false};
-
+	static void staticUpdateThreadEntry(thread_call_param_t param0, thread_call_param_t param1);
+	
 	/**
-	 *  Update sensors values, must be guarded by mainLock
+	 *  Update sensors values
 	 */
-	void updateSensors();
-
+	void updateSensorsLoop();
+	
+	/*
+	 * Handle SMC updates in idle
+	 */
+	void handleSmcUpdatesInIdle(int idle_loop_count);
+	
+	/**
+	 *  SMC update handlers
+	 */
+	void hanldeManualControlUpdate(size_t index, UInt8 *data);
+	void hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data);
+	void handleManualForceFanControlUpdate(UInt8 *data);
+	
 private:
 	int  i8k_smm(SMMRegisters *regs);
 	bool i8k_get_dell_sig_aux(int fn);
-	bool i8k_get_dell_signature(void);
+	bool i8k_get_dell_signature();
 	int  i8k_get_temp(int sensor);
 	int  i8k_get_temp_type(int sensor);
-	int  i8k_get_power_status(void);
+	int  i8k_get_power_status();
 	int  i8k_get_fan_speed(int fan);
 	int  i8k_get_fan_status(int fan);
 	int  i8k_get_fan_type(int fan);
 	int  i8k_get_fan_nominal_speed(int fan, int speed);
 
-public:
 	int  i8k_set_fan(int fan, int speed);
 	int  i8k_set_fan_control_manual(int fan);
 	int  i8k_set_fan_control_auto(int fan);
 };
+
+// Helper definitions
+static constexpr SMC_KEY KeyF0Md = SMC_MAKE_IDENTIFIER('F',0,'M','d');
+static constexpr SMC_KEY KeyF0Tg = SMC_MAKE_IDENTIFIER('F',0,'T','g');
+static constexpr SMC_KEY KeyFS__ = SMC_MAKE_IDENTIFIER('F','S','!',' ');
+
+inline UInt16 swap_value(UInt16 value)
+{
+	return ((value & 0xff00) >> 8) | ((value & 0xff) << 8);
+}
+
+inline UInt16 encode_fpe2(UInt16 value) {
+	return swap_value(value << 2);
+}
+
+inline UInt16 decode_fpe2(UInt16 value) {
+	return (swap_value(value) >> 2);
+}
 
 #endif /* SMIMonitor_hpp */

--- a/Sensors/SMCProcessor/KeyImplementations.cpp
+++ b/Sensors/SMCProcessor/KeyImplementations.cpp
@@ -11,7 +11,7 @@
 SMC_RESULT TempPackage::readAccess() {
 	uint16_t *ptr = reinterpret_cast<uint16_t *>(data);
 	IOSimpleLockLock(cp->counterLock);
-	*ptr = VirtualSMCAPI::encodeSp(type, cp->counters.tjmax[package] - cp->counters.thermalStatusPackage[package]);
+	*ptr = VirtualSMCAPI::encodeIntSp(type, cp->counters.tjmax[package] - cp->counters.thermalStatusPackage[package]);
 	cp->quickReschedule();
 	IOSimpleLockUnlock(cp->counterLock);
 	return SmcSuccess;
@@ -20,7 +20,7 @@ SMC_RESULT TempPackage::readAccess() {
 SMC_RESULT TempCore::readAccess() {
 	uint16_t *ptr = reinterpret_cast<uint16_t *>(data);
 	IOSimpleLockLock(cp->counterLock);
-	*ptr = VirtualSMCAPI::encodeSp(type, cp->counters.tjmax[package] - cp->counters.thermalStatus[core]);
+	*ptr = VirtualSMCAPI::encodeIntSp(type, cp->counters.tjmax[package] - cp->counters.thermalStatus[core]);
 	cp->quickReschedule();
 	IOSimpleLockUnlock(cp->counterLock);
 	return SmcSuccess;
@@ -29,7 +29,7 @@ SMC_RESULT TempCore::readAccess() {
 SMC_RESULT VoltagePackage::readAccess() {
 	uint16_t *ptr = reinterpret_cast<uint16_t *>(data);
 	IOSimpleLockLock(cp->counterLock);
-	*ptr = VirtualSMCAPI::encodeSp(type, cp->counters.voltage[package]);
+	*ptr = VirtualSMCAPI::encodeIntSp(type, cp->counters.voltage[package]);
 	cp->quickReschedule();
 	IOSimpleLockUnlock(cp->counterLock);
 	return SmcSuccess;
@@ -43,7 +43,7 @@ SMC_RESULT CpEnergyKey::readAccess() {
 	if (type == SmcKeyTypeFloat)
 		*reinterpret_cast<uint32_t *>(data) = VirtualSMCAPI::encodeFlt(val);
 	else
-		*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(type, val);
+		*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntSp(type, val);
 	cp->quickReschedule();
 	IOSimpleLockUnlock(cp->counterLock);
 	return SmcSuccess;

--- a/Sensors/SMCSuperIO/SuperIODevice.cpp
+++ b/Sensors/SMCSuperIO/SuperIODevice.cpp
@@ -50,9 +50,9 @@ void SuperIODevice::updateIORegistry() {
  */
 SMC_RESULT TachometerKey::readAccess() {
 	IOSimpleLockLock(sio->counterLock);
-	double val = device->getTachometerValue(index);
+	auto val = device->getTachometerValue(index);
 	const_cast<SMCSuperIO*>(sio)->quickReschedule();
 	IOSimpleLockUnlock(sio->counterLock);
-	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeFp(SmcKeyTypeFpe2, val);
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, val);
 	return SmcSuccess;
 }

--- a/VirtualSMC/kern_vsmcapi.cpp
+++ b/VirtualSMC/kern_vsmcapi.cpp
@@ -183,18 +183,35 @@ uint16_t VirtualSMCAPI::encodeFp(uint32_t type, double value) {
 }
 
 int16_t VirtualSMCAPI::decodeIntSp(uint32_t type, uint16_t value) {
+	uint32_t integral = getSpIntegral(type);
+	if (integral == 0)
+		return 0;
+	value = OSSwapInt16(value);
+	int16_t ret = (value & 0x7FFF) >> (15U - integral);
+	return (value & 0x8000) ? -ret : ret;
+}
+
+uint16_t VirtualSMCAPI::encodeIntSp(uint32_t type, int16_t value) {
+	uint32_t integral = getSpIntegral(type);
+	if (integral == 0)
+		return 0;
+	uint16_t ret = static_cast<uint16_t>(__builtin_abs(value) << (15U - integral)) & 0x7FFF;
+	return OSSwapInt16(value < 0 ? (ret | 0x8000) : ret);
+}
+
+uint16_t VirtualSMCAPI::decodeIntFp(uint32_t type, uint16_t value) {
 	uint32_t integral = getFpIntegral(type);
 	if (integral == 0)
 		return 0;
 	value = OSSwapInt16(value);
-	int16_t ret = value / static_cast<int16_t>(getBit<uint16_t>(16 - integral));
+	int16_t ret = value >> (16U - integral);
 	return ret;
 }
 
-uint16_t VirtualSMCAPI::encodeIntSp(uint32_t type, int16_t value) {
+uint16_t VirtualSMCAPI::encodeIntFp(uint32_t type, uint16_t value) {
 	uint32_t integral = getFpIntegral(type);
 	if (integral == 0)
 		return 0;
-	uint16_t ret = static_cast<uint16_t>(__builtin_abs(value) * getBit<uint16_t>(16 - integral));
+	uint16_t ret = static_cast<uint16_t>(value << (16U - integral));
 	return OSSwapInt16(ret);
 }

--- a/VirtualSMC/kern_vsmcapi.cpp
+++ b/VirtualSMC/kern_vsmcapi.cpp
@@ -181,3 +181,20 @@ uint16_t VirtualSMCAPI::encodeFp(uint32_t type, double value) {
 	uint16_t ret = static_cast<uint16_t>(__builtin_fabs(value) * getBit<uint16_t>(16 - integral));
 	return OSSwapInt16(ret);
 }
+
+int16_t VirtualSMCAPI::decodeIntSp(uint32_t type, uint16_t value) {
+	uint32_t integral = getFpIntegral(type);
+	if (integral == 0)
+		return 0;
+	value = OSSwapInt16(value);
+	int16_t ret = value / static_cast<int16_t>(getBit<uint16_t>(16 - integral));
+	return ret;
+}
+
+uint16_t VirtualSMCAPI::encodeIntSp(uint32_t type, int16_t value) {
+	uint32_t integral = getFpIntegral(type);
+	if (integral == 0)
+		return 0;
+	uint16_t ret = static_cast<uint16_t>(__builtin_abs(value) * getBit<uint16_t>(16 - integral));
+	return OSSwapInt16(ret);
+}

--- a/VirtualSMCSDK/kern_vsmcapi.hpp
+++ b/VirtualSMCSDK/kern_vsmcapi.hpp
@@ -152,6 +152,26 @@ namespace VirtualSMCAPI {
 	EXPORT uint16_t encodeFp(uint32_t type, double value);
 
 	/**
+	 *  Decode Apple FP signed integral number
+	 *
+	 *  @param type  encoding type, e.g. SmcKeyTypeFpe2
+	 *  @param value value as it is read from SMC_DATA field
+	 *
+	 *  @return floating point value
+	 */
+	EXPORT int16_t decodeIntSp(uint32_t type, uint16_t value);
+
+	/**
+	 *  Encode Apple FP signed integral number
+	 *
+	 *  @param type  encoding type, e.g. SmcKeyTypeFpe2
+	 *  @param value source value
+	 *
+	 *  @return value as it is to be written to SMC_DATA field
+	 */
+	EXPORT uint16_t encodeIntSp(uint32_t type, int16_t value);
+
+	/**
 	 *  Decode Apple float fractional format
 	 *
 	 *  @param value value as it is read from SMC_DATA field

--- a/VirtualSMCSDK/kern_vsmcapi.hpp
+++ b/VirtualSMCSDK/kern_vsmcapi.hpp
@@ -154,7 +154,7 @@ namespace VirtualSMCAPI {
 	/**
 	 *  Decode Apple FP signed integral number
 	 *
-	 *  @param type  encoding type, e.g. SmcKeyTypeFpe2
+	 *  @param type  encoding type, e.g. SmcKeyTypeSp78
 	 *  @param value value as it is read from SMC_DATA field
 	 *
 	 *  @return floating point value
@@ -164,12 +164,32 @@ namespace VirtualSMCAPI {
 	/**
 	 *  Encode Apple FP signed integral number
 	 *
-	 *  @param type  encoding type, e.g. SmcKeyTypeFpe2
+	 *  @param type  encoding type, e.g. SmcKeyTypeSp78
 	 *  @param value source value
 	 *
 	 *  @return value as it is to be written to SMC_DATA field
 	 */
 	EXPORT uint16_t encodeIntSp(uint32_t type, int16_t value);
+
+	/**
+	 *  Decode Apple FP unsigned integral number
+	 *
+	 *  @param type  encoding type, e.g. SmcKeyTypeFpe2
+	 *  @param value value as it is read from SMC_DATA field
+	 *
+	 *  @return floating point value
+	 */
+	EXPORT uint16_t decodeIntFp(uint32_t type, uint16_t value);
+
+	/**
+	 *  Encode Apple FP unsigned integral number
+	 *
+	 *  @param type  encoding type, e.g. SmcKeyTypeFpe2
+	 *  @param value source value
+	 *
+	 *  @return value as it is to be written to SMC_DATA field
+	 */
+	EXPORT uint16_t encodeIntFp(uint32_t type, uint16_t value);
 
 	/**
 	 *  Decode Apple float fractional format


### PR DESCRIPTION
In this PR I refactored reading and writing to SMM in order to not use mp_rendezvous_no_intrs/mp_rendezvous since they lock all CPUs and their implementation is quite resource-consuming.
New implementation uses only one thread binded to CPU core 0.
Nevertheless, this approach cannot fix audio lags in Safari + Audio/Video + Bluetooth headset/speaker.
But it is possible to reduce these lags by changing "Audio options" in Bluetooth Explorer:
Menu Tools -> Audio Options.. -> Buffer of maximum of [x] packets, here you can set 255 for example.