### PR TITLE
Reduce audio lags while accessing smm

### DIFF
--- a/Sensors/SMCDellSensors/SMCDellSensors.cpp
+++ b/Sensors/SMCDellSensors/SMCDellSensors.cpp
@@ -36,14 +36,14 @@ IOService *SMCDellSensors::probe(IOService *provider, SInt32 *score) {
 		SYSLOG("sdell", "failed to probe the parent");
 		return nullptr;
 	}
-	
+
 	if (!SMIMonitor::getShared()->probe())
 		return nullptr;
-	
+
 	auto fanCount = min(SMIMonitor::getShared()->fanCount, MaxIndexCount);
 	VirtualSMCAPI::addKey(KeyFNum, vsmcPlugin.data,
 		VirtualSMCAPI::valueWithUint8(fanCount, nullptr, SMC_KEY_ATTRIBUTE_CONST | SMC_KEY_ATTRIBUTE_READ));
-	
+
 	for (size_t i = 0; i < fanCount; i++) {
 		VirtualSMCAPI::addKey(KeyF0Ac(i), vsmcPlugin.data, VirtualSMCAPI::valueWithFp(0, SmcKeyTypeFpe2, new F0Ac(i), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
 		VirtualSMCAPI::addKey(KeyF0Mn(i), vsmcPlugin.data, VirtualSMCAPI::valueWithFp(0, SmcKeyTypeFpe2, new F0Mn(i), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
@@ -75,7 +75,7 @@ IOService *SMCDellSensors::probe(IOService *provider, SInt32 *score) {
 		VirtualSMCAPI::addKey(KeyF0ID(i), vsmcPlugin.data, VirtualSMCAPI::valueWithData(
 			reinterpret_cast<const SMC_DATA *>(&desc), sizeof(desc), SmcKeyTypeFds, nullptr, SMC_KEY_ATTRIBUTE_CONST | SMC_KEY_ATTRIBUTE_READ));
 	}
-	
+
 	auto tempCount = min(SMIMonitor::getShared()->tempCount, MaxIndexCount);
 	for (size_t i = 0; i < tempCount; i++) {
 		TempInfo::SMMTempSensorType type = SMIMonitor::getShared()->state.tempInfo[i].type;
@@ -83,7 +83,7 @@ IOService *SMCDellSensors::probe(IOService *provider, SInt32 *score) {
 			DBGLOG("sdell", "Temp sensor type %d is unknown, auto assign value %d", type, SMIMonitor::getShared()->state.tempInfo[i].index);
 			type = static_cast<TempInfo::SMMTempSensorType>(SMIMonitor::getShared()->state.tempInfo[i].index);
 		}
-		
+
 		switch (type)
 		{
 		case TempInfo::CPU:
@@ -115,9 +115,9 @@ IOService *SMCDellSensors::probe(IOService *provider, SInt32 *score) {
 			break;
 		}
 	}
-	
+
 	qsort(const_cast<VirtualSMCKeyValue *>(vsmcPlugin.data.data()), vsmcPlugin.data.size(), sizeof(VirtualSMCKeyValue), VirtualSMCKeyValue::compare);
-	
+
 	return this;
 }
 
@@ -126,15 +126,15 @@ bool SMCDellSensors::start(IOService *provider) {
 		SYSLOG("sdell", "failed to start the parent");
 		return false;
 	}
-	
+
 	SMIMonitor::getShared()->start();
-	
+
 	PMinit();
 	provider->joinPMtree(this);
 	registerPowerDriver(this, powerStates, arrsize(powerStates));
-	
+
 	ADDPR(startSuccess) = true;
-	
+
 	vsmcNotifier = VirtualSMCAPI::registerHandler(vsmcNotificationHandler, this);
 	return vsmcNotifier != nullptr;
 }

--- a/Sensors/SMCDellSensors/SMCDellSensors.cpp
+++ b/Sensors/SMCDellSensors/SMCDellSensors.cpp
@@ -39,14 +39,6 @@ IOService *SMCDellSensors::probe(IOService *provider, SInt32 *score) {
 	
 	if (!SMIMonitor::getShared()->probe())
 		return nullptr;
-
-//	if (!ADDPR(startSuccess))
-//	{
-//		DBGLOG("sdell", "probing with lilu offline");
-//		KERNELHOOKS::getInstance();
-//	}
-
-	//WARNING: watch out, key addition is sorted here!
 	
 	auto fanCount = min(SMIMonitor::getShared()->fanCount, MaxIndexCount);
 	VirtualSMCAPI::addKey(KeyFNum, vsmcPlugin.data,

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -28,9 +28,9 @@ int SMIMonitor::i8k_smm(SMMRegisters *regs) {
 	
 	smmIsBeingRead = true;
 	int attempts = 10;
-	while (KERNELHOOKS::audioSamplesAvailable && --attempts >= 0)
+	while (KERNELHOOKS::areAudioSamplesAvailable() && --attempts >= 0)
 		IOSleep(1);
-	if (KERNELHOOKS::audioSamplesAvailable) {
+	if (KERNELHOOKS::areAudioSamplesAvailable()) {
 		smmIsBeingRead = false;
 		return -1;
 	}
@@ -530,7 +530,7 @@ void SMIMonitor::updateSensorsLoop() {
 		
 		for (int i=0; i<fanCount && awake; ++i)
 		{
-			if (!KERNELHOOKS::audioSamplesAvailable)
+			if (!KERNELHOOKS::areAudioSamplesAvailable())
 			{
 				int sensor = state.fanInfo[i].index;
 				int rc = i8k_get_fan_speed(sensor);
@@ -544,7 +544,7 @@ void SMIMonitor::updateSensorsLoop() {
 
 		for (int i=0; i<tempCount && awake; ++i)
 		{
-			if (!KERNELHOOKS::audioSamplesAvailable)
+			if (!KERNELHOOKS::areAudioSamplesAvailable())
 			{
 				int sensor = state.tempInfo[i].index;
 				int rc = i8k_get_temp(sensor);

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -18,26 +18,28 @@ extern "C" {
 }
 
 SMIMonitor *SMIMonitor::instance = nullptr;
-atomic_flag SMIMonitor::busy = {};
+atomic_bool SMIMonitor::busy = 0;
 
 OSDefineMetaClassAndStructors(SMIMonitor, OSObject)
 
 int SMIMonitor::i8k_smm(SMMRegisters *regs) {
 	int rc;
 	int eax = regs->eax;  //input value
-	
-	while (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
-	{
+
+	uint32_t attempts = 0;
+	while (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire)) {
 		IOSleep(20);
-		//SYSLOG("sdell", "currently audio engine user client performs input/output, active_outputs = %d", atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire));
+		if (++attempts % 100 == 0) {
+			//SYSLOG("sdell", "currently audio engine user client performs input/output, active_outputs = %d", atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire));
+			KERNELHOOKS::activateTimer();
+		}
 	}
+
+	atomic_store_explicit(&busy, true, memory_order_release);
 	
-	atomic_flag_test_and_set_explicit(&busy, memory_order_acquire);
-	
-	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
-	{
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire)) {
 		//SYSLOG("sdell", "break access smm, active_outputs = %d", atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire));
-		atomic_flag_clear_explicit(&busy, memory_order_release);
+		atomic_store_explicit(&busy, false, memory_order_release);
 		return -1;
 	}
 
@@ -95,8 +97,8 @@ int SMIMonitor::i8k_smm(SMMRegisters *regs) {
 			: "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #endif
 	
-	atomic_flag_clear_explicit(&busy, memory_order_release);
-
+	atomic_store_explicit(&busy, false, memory_order_release);
+	
 	if ((rc != 0) || ((regs->eax & 0xffff) == 0xffff) || (regs->eax == eax)) {
 		return -1;
 	}

--- a/Sensors/SMCDellSensors/SMIMonitor.cpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.cpp
@@ -24,9 +24,9 @@ OSDefineMetaClassAndStructors(SMIMonitor, OSObject)
 int SMIMonitor::i8k_smm(SMMRegisters *regs) {
 	int rc;
 	int eax = regs->eax;  //input value
-	
+
 	while (atomic_flag_test_and_set_explicit(&KERNELHOOKS::busy, memory_order_acquire)) { IOSleep(0); }
-		
+
 #if __LP64__
 	asm volatile("pushq %%rax\n\t"
 			"movl 0(%%rax),%%edx\n\t"
@@ -80,7 +80,7 @@ int SMIMonitor::i8k_smm(SMMRegisters *regs) {
 			: "a"(regs)
 			: "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
 #endif
-	
+
 	atomic_flag_clear_explicit(&KERNELHOOKS::busy, memory_order_release);
 
 	if ((rc != 0) || ((regs->eax & 0xffff) == 0xffff) || (regs->eax == eax)) {
@@ -261,7 +261,7 @@ void SMIMonitor::createShared() {
 bool SMIMonitor::probe() {
 
 	bool success = true;
-	
+
 	while (!updateCall) {
 		updateCall = thread_call_allocate_with_priority(staticUpdateThreadEntry, this, THREAD_CALL_PRIORITY_KERNEL);
 		if (!updateCall) {
@@ -269,7 +269,7 @@ bool SMIMonitor::probe() {
 			success = false;
 			break;
 		}
-		
+
 		IOLockLock(mainLock);
 		thread_call_enter(updateCall);
 		
@@ -294,7 +294,7 @@ bool SMIMonitor::probe() {
 			updateCall = nullptr;
 		}
 	}
-	
+
 	DBGLOG("sdell", "Based on I8kfan project and adopted to VirtualSMC plugin");
 
 	return success;
@@ -321,7 +321,7 @@ bool SMIMonitor::postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint
 
 	bool success = false;
 	while (1) {
-	
+
 		if (dataSize > sizeof(StoredSmcUpdate::data)) {
 			SYSLOG("sdell", "postRequest dataSize overflow %u", dataSize);
 			break;
@@ -367,17 +367,17 @@ IOReturn SMIMonitor::bindCurrentThreadToCpu0()
 	// Obtain power management callbacks 10.7+
 	pmCallBacks_t callbacks {};
 	pmKextRegister(PM_DISPATCH_VERSION, nullptr, &callbacks);
-	
+
 	if (!callbacks.LCPUtoProcessor) {
 		SYSLOG("sdell", "failed to obtain LCPUtoProcessor");
 		return KERN_FAILURE;
 	}
-	
+
 	if (!callbacks.ThreadBind) {
 		SYSLOG("sdell", "failed to obtain ThreadBind");
 		return KERN_FAILURE;
 	}
-	
+
 	if (!IOSimpleLockTryLock(preemptionLock)) {
 		SYSLOG("sdell", "Preemption cannot be disabled before performing ThreadBind");
 		return KERN_FAILURE;
@@ -385,7 +385,7 @@ IOReturn SMIMonitor::bindCurrentThreadToCpu0()
 
 	bool success = true;
 	auto enable = ml_set_interrupts_enabled(FALSE);
-	
+
 	while (1)
 	{
 		auto processor = callbacks.LCPUtoProcessor(0);

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -160,7 +160,7 @@ public:
 	 *  Post request
 	 */
 	bool postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint32_t dataSize);
-		
+
 	/**
 	 *  Main refreshed battery state containing battery information
 	 */
@@ -186,7 +186,7 @@ public:
 	 */
 	_Atomic(int) fanMult = 1;
 
-	
+
 private:
 	/**
 	 *  The only allowed battery manager instance
@@ -217,7 +217,7 @@ private:
 	 *  variable-event, keeps thread initialization result (0 or error code)
 	 */
 	_Atomic(int) initialized = -1;
-	
+
 	/**
 	 *  Awake flag
 	 */
@@ -227,12 +227,12 @@ private:
 	 *  Stored events for writing to SMM (event queue)
 	 */
 	evector<StoredSmcUpdate&> storedSmcUpdates;
-	
+
 	/**
 	 *  Smc updates may happen which have to be handled in thread binded to CPU 0
 	 */
 	static constexpr size_t MaxActiveSmcUpdates {40};
-		
+
 private:
 
 	/**

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -185,6 +185,9 @@ public:
 	 *  Fan multiplier
 	 */
 	_Atomic(int) fanMult = 1;
+	
+	
+	static atomic_flag busy;
 
 
 private:

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -162,6 +162,11 @@ public:
 	bool postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint32_t dataSize);
 	
 	/**
+	 *  Returns true if SMM is being read
+	 */
+	static bool IsSmmBeingRead();
+	
+	/**
 	 *  Main refreshed battery state containing battery information
 	 */
 	SMIState state {};
@@ -185,11 +190,6 @@ public:
 	 *  Fan multiplier
 	 */
 	_Atomic(int) fanMult = 1;
-	
-	/**
-	 *  Flag is set while SMM is being read
-	 */
-	static _Atomic(bool) volatile smmIsBeingRead;
 
 	
 private:
@@ -232,6 +232,11 @@ private:
 	 *  Stored events for writing to SMM (event queue)
 	 */
 	evector<StoredSmcUpdate&> storedSmcUpdates;
+	
+	/**
+	 *  Flag is set while SMM is being read
+	 */
+	static _Atomic(bool) smmIsBeingRead;
 
 	/**
 	 *  Smc updates may happen which have to be handled in thread binded to CPU 0

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -160,7 +160,7 @@ public:
 	 *  Post request
 	 */
 	bool postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint32_t dataSize);
-
+	
 	/**
 	 *  Main refreshed battery state containing battery information
 	 */
@@ -185,6 +185,12 @@ public:
 	 *  Fan multiplier
 	 */
 	_Atomic(int) fanMult = 1;
+	
+	/**
+	 *  Flag is set while SMM is being read
+	 */
+	static _Atomic(bool) volatile smmIsBeingRead;
+
 	
 private:
 	/**
@@ -231,6 +237,8 @@ private:
 	 *  Smc updates may happen which have to be handled in thread binded to CPU 0
 	 */
 	static constexpr size_t MaxActiveSmcUpdates {40};
+		
+private:
 
 	/**
 	 *  Bind working thread to CPU 0
@@ -276,7 +284,6 @@ private:
 	void hanldeManualTargetSpeedUpdate(size_t index, UInt8 *data);
 	void handleManualForceFanControlUpdate(UInt8 *data);
 
-private:
 	int  i8k_smm(SMMRegisters *regs);
 	bool i8k_get_dell_sig_aux(int fn);
 	bool i8k_get_dell_signature();

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -169,25 +169,25 @@ public:
 	/**
 	 *  Actual fan control status
 	 */
-	_Atomic(uint16_t)	fansStatus = 0;
+	atomic_uint_fast16_t fansStatus = 0;
 
 	/**
 	 *  Actual fan count
 	 */
-	_Atomic(uint32_t) fanCount = 0;
+	atomic_uint fanCount = 0;
 
 	/**
 	 *  Actual temperature sensors count
 	 */
-	_Atomic(uint32_t) tempCount = 0;
+	atomic_uint tempCount = 0;
 
 	/**
 	 *  Fan multiplier
 	 */
-	_Atomic(int) fanMult = 1;
+	atomic_int fanMult = 1;
 	
 	
-	static atomic_flag busy;
+	static atomic_bool busy;
 
 
 private:
@@ -219,12 +219,12 @@ private:
 	/**
 	 *  variable-event, keeps thread initialization result (0 or error code)
 	 */
-	_Atomic(int) initialized = -1;
+	atomic_int initialized = -1;
 
 	/**
 	 *  Awake flag
 	 */
-	_Atomic(bool) awake = true;
+	atomic_bool awake = true;
 
 	/**
 	 *  Stored events for writing to SMM (event queue)

--- a/Sensors/SMCDellSensors/SMIMonitor.hpp
+++ b/Sensors/SMCDellSensors/SMIMonitor.hpp
@@ -160,12 +160,7 @@ public:
 	 *  Post request
 	 */
 	bool postSmcUpdate(SMC_KEY key, size_t index, const void *data, uint32_t dataSize);
-	
-	/**
-	 *  Returns true if SMM is being read
-	 */
-	static bool IsSmmBeingRead();
-	
+		
 	/**
 	 *  Main refreshed battery state containing battery information
 	 */
@@ -233,11 +228,6 @@ private:
 	 */
 	evector<StoredSmcUpdate&> storedSmcUpdates;
 	
-	/**
-	 *  Flag is set while SMM is being read
-	 */
-	static _Atomic(bool) smmIsBeingRead;
-
 	/**
 	 *  Smc updates may happen which have to be handled in thread binded to CPU 0
 	 */

--- a/Sensors/SMCDellSensors/SMIState.hpp
+++ b/Sensors/SMCDellSensors/SMIState.hpp
@@ -30,13 +30,13 @@ struct FanInfo {
 		Last
 	};
 	
-	_Atomic(int)		index   	 = ValueUnknown;
-	_Atomic(int)		status  	 = ValueUnknown;
-	_Atomic(SMMFanType)	type    	 = Unsupported;
-	_Atomic(int)		minSpeed	 = ValueUnknown;
-	_Atomic(int)		maxSpeed	 = ValueUnknown;
-	_Atomic(int)		targetSpeed  = 0;
-	_Atomic(int)		speed   	 = 0;
+	atomic_int		index   	 = ValueUnknown;
+	atomic_int		status  	 = ValueUnknown;
+	_Atomic(SMMFanType)	type   	 = Unsupported;
+	atomic_int		minSpeed	 = ValueUnknown;
+	atomic_int		maxSpeed	 = ValueUnknown;
+	atomic_int		targetSpeed  = 0;
+	atomic_int		speed   	 = 0;
 };
 
 /**
@@ -58,9 +58,9 @@ struct TempInfo {
 		Last
 	};
 	
-	_Atomic(int)				index = ValueUnknown;
+	atomic_int					index = ValueUnknown;
 	_Atomic(SMMTempSensorType)	type  = Unsupported;
-	_Atomic(int)				temp  = ValueUnknown;
+	atomic_int					temp  = ValueUnknown;
 };
 
 /**

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -78,7 +78,7 @@ int64_t KERNELHOOKS::IOBluetoothDevice_moreIncomingData(void *that, void *arg1, 
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	int64_t result = FunctionCast(IOBluetoothDevice_moreIncomingData,
 							  callbackKERNELHOOKS->orgIOBluetoothDevice_moreIncomingData)(that, arg1, arg2);
-	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
 		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
@@ -89,7 +89,7 @@ int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_writeWL(void *that, void 
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_writeWL,
 							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_writeWL)(that, arg1, arg2, arg3, arg4);
-	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
 		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
@@ -100,7 +100,7 @@ int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_writeOOLWL(void *that, ui
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_writeOOLWL,
 							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_writeOOLWL)(that, arg1, arg2, arg3, arg4);
-	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
 		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -38,7 +38,7 @@ void KERNELHOOKS::deinit()
 
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) { IOSleep(0); }
+	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) {}
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientOutput)(that, firstSampleFrame, loopCount, bufferSet, sampleIntervalHi, sampleIntervalLo);
 	atomic_flag_clear_explicit(&busy, memory_order_release);
@@ -47,7 +47,7 @@ IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UI
 
 void KERNELHOOKS::IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) { IOSleep(0); }
+	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) {}
 	FunctionCast(IOAudioEngineUserClient_performWatchdogOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performWatchdogOutput)(that, clientBufferSet, generationCount);
 	atomic_flag_clear_explicit(&busy, memory_order_release);

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -12,11 +12,15 @@
 #include "SMIMonitor.hpp"
 
 static KERNELHOOKS *callbackKERNELHOOKS = nullptr;
-atomic_flag KERNELHOOKS::busy = {};
+_Atomic(uint32_t) KERNELHOOKS::active_output = 0;
 
-static const char *kextIOAudioFamily[] { "/System/Library/Extensions/IOAudioFamily.kext/Contents/MacOS/IOAudioFamily" };
-
-static KernelPatcher::KextInfo kextIOAudio { "com.apple.iokit.IOAudioFamily", kextIOAudioFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded };
+static const char *kextIOAudioFamily[]     { "/System/Library/Extensions/IOAudioFamily.kext/Contents/MacOS/IOAudioFamily" };
+static const char *kextIOBluetoothFamily[] { "/System/Library/Extensions/IOBluetoothFamily.kext/Contents/MacOS/IOBluetoothFamily" };
+static constexpr size_t kextListSize {2};
+static KernelPatcher::KextInfo kextList[kextListSize] {
+	{ "com.apple.iokit.IOAudioFamily", kextIOAudioFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded },
+	{ "com.apple.iokit.IOBluetoothFamily", kextIOBluetoothFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded}
+};
 
 bool KERNELHOOKS::init()
 {
@@ -24,7 +28,7 @@ bool KERNELHOOKS::init()
 	
 	callbackKERNELHOOKS = this;
 
-	lilu.onKextLoadForce(&kextIOAudio, 1,
+	lilu.onKextLoadForce(kextList, kextListSize,
 	[](void *user, KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 		callbackKERNELHOOKS->processKext(patcher, index, address, size);
 	}, this);
@@ -38,34 +42,99 @@ void KERNELHOOKS::deinit()
 
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientOutput)(that, firstSampleFrame, loopCount, bufferSet, sampleIntervalHi, sampleIntervalLo);
-	atomic_flag_clear_explicit(&busy, memory_order_release);
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
 
 void KERNELHOOKS::IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	FunctionCast(IOAudioEngineUserClient_performWatchdogOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performWatchdogOutput)(that, clientBufferSet, generationCount);
-	atomic_flag_clear_explicit(&busy, memory_order_release);
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 }
 
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientInput(void *that, UInt32 firstSampleFrame, void *bufferSet)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientInput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientInput)(that, firstSampleFrame, bufferSet);
-	atomic_flag_clear_explicit(&busy, memory_order_release);
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
+	return result;
+}
+
+int64_t KERNELHOOKS::IOBluetoothDevice_moreIncomingData(void *that, void *arg1, unsigned int arg2)
+{
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
+	int64_t result = FunctionCast(IOBluetoothDevice_moreIncomingData,
+							  callbackKERNELHOOKS->orgIOBluetoothDevice_moreIncomingData)(that, arg1, arg2);
+	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
+	return result;
+}
+
+int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_writeWL(void *that, void *arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4)
+{
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
+	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_writeWL,
+							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_writeWL)(that, arg1, arg2, arg3, arg4);
+	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
+	return result;
+}
+
+int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_writeOOLWL(void *that, uint64_t arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4)
+{
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
+	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_writeOOLWL,
+							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_writeOOLWL)(that, arg1, arg2, arg3, arg4);
+	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
+	return result;
+}
+
+int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap(void *that, void *arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4)
+{
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
+
+	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap,
+							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap)(that, arg1, arg2, arg3, arg4);
+	// called method will call finally IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent (if result is KERN_SUCCESS)
+	if (result != KERN_SUCCESS)
+	{
+		if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+			atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
+	}
+	return result;
+}
+
+int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent(void *that, IOService *service, void *channel, int arg1, uint64_t arg2, uint64_t arg3)
+{
+	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent,
+								  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent)(that, service, channel, arg1, arg2, arg3);
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
 
 void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size)
 {
-	if (kextIOAudio.loadIndex == index) {
-		DBGLOG("sdell", "%s", kextIOAudio.id);
+	if (kextList[0].loadIndex == index) {
+		SYSLOG("sdell", "%s", kextList[0].id);
 
 		KernelPatcher::RouteRequest requests[] {
 			{"__ZN23IOAudioEngineUserClient19performClientOutputEjjP22IOAudioClientBufferSetjj", IOAudioEngineUserClient_performClientOutput, orgIOAudioEngineUserClient_performClientOutput},
@@ -74,9 +143,28 @@ void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_addr
 		};
 		patcher.routeMultiple(index, requests, address, size);
 		if (patcher.getError() == KernelPatcher::Error::NoError) {
-			DBGLOG("sdell", "routed is successful");
+			DBGLOG("sdell", "%s routed is successful", kextList[0].id);
 		} else {
-			SYSLOG("sdell", "failed to resolve at least one of symbols, error = %d", patcher.getError());
+			SYSLOG("sdell", "failed to resolve at least one of symbols in %s, error = %d", kextList[0].id, patcher.getError());
+			patcher.clearError();
+		}
+	}
+
+	if (kextList[1].loadIndex == index) {
+		SYSLOG("sdell", "%s", kextList[1].id);
+
+		KernelPatcher::RouteRequest requests[] {
+			{"__ZN17IOBluetoothDevice16moreIncomingDataEPvj", IOBluetoothDevice_moreIncomingData, orgIOBluetoothDevice_moreIncomingData},
+			{"__ZN33IOBluetoothL2CAPChannelUserClient7writeWLEPvtyy", IOBluetoothL2CAPChannelUserClient_writeWL, orgIOBluetoothL2CAPChannelUserClient_writeWL},
+			{"__ZN33IOBluetoothL2CAPChannelUserClient10writeOOLWLEytyy", IOBluetoothL2CAPChannelUserClient_writeOOLWL, orgIOBluetoothL2CAPChannelUserClient_writeOOLWL},
+			{"__ZN33IOBluetoothL2CAPChannelUserClient24WriteAsyncAudioData_TrapEPvtyy", IOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap, orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap},
+			{"__ZN33IOBluetoothL2CAPChannelUserClient23callBackAfterDataIsSentEP9IOServiceP23IOBluetoothL2CAPChanneliyy", IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent, orgIOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent}
+		};
+		patcher.routeMultiple(index, requests, address, size);
+		if (patcher.getError() == KernelPatcher::Error::NoError) {
+			DBGLOG("sdell", "%s routed is successful", kextList[1].id);
+		} else {
+			SYSLOG("sdell", "failed to resolve at least one of symbols in %s, error = %d", kextList[1].id, patcher.getError());
 			patcher.clearError();
 		}
 	}

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -12,8 +12,7 @@
 #include "SMIMonitor.hpp"
 
 static KERNELHOOKS *callbackKERNELHOOKS = nullptr;
-_Atomic(uint32_t) KERNELHOOKS::outputCounter = 0;
-_Atomic(AbsoluteTime) KERNELHOOKS::last_audio_event = 0;
+atomic_flag KERNELHOOKS::busy = {};
 
 static const char *kextIOAudioFamily[] { "/System/Library/Extensions/IOAudioFamily.kext/Contents/MacOS/IOAudioFamily" };
 
@@ -37,44 +36,21 @@ void KERNELHOOKS::deinit()
 {
 }
 
-bool KERNELHOOKS::areAudioSamplesAvailable()
-{
-	AbsoluteTime prev_time = atomic_load_explicit(&last_audio_event, memory_order_acquire);
-	if (prev_time != 0) {
-		uint64_t        nsecs;
-		AbsoluteTime    cur_time;
-		clock_get_uptime(&cur_time);
-		SUB_ABSOLUTETIME(&cur_time, &prev_time);
-		absolutetime_to_nanoseconds(cur_time, &nsecs);
-		if (nsecs > 60000000000) {
-			atomic_store_explicit(&outputCounter, 0, memory_order_release);
-			atomic_store_explicit(&last_audio_event, 0, memory_order_seq_cst);
-		}
-	}
-	
-	return atomic_load_explicit(&outputCounter, memory_order_acquire) > 0;
-}
-
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo)
 {
-	while (SMIMonitor::IsSmmBeingRead()) {}
-	atomic_fetch_add_explicit(&outputCounter, 1, memory_order_release);
-	AbsoluteTime cur_time;
-	clock_get_uptime(&cur_time);
-	atomic_store_explicit(&last_audio_event, cur_time, memory_order_seq_cst);
+	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) { IOSleep(0); }
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientOutput)(that, firstSampleFrame, loopCount, bufferSet, sampleIntervalHi, sampleIntervalLo);
-	atomic_fetch_sub_explicit(&outputCounter, 1, memory_order_release);
+	atomic_flag_clear_explicit(&busy, memory_order_release);
 	return result;
 }
 
 void KERNELHOOKS::IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount)
 {
-	while (SMIMonitor::IsSmmBeingRead()) {}
-	atomic_fetch_add_explicit(&outputCounter, 1, memory_order_release);
+	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) { IOSleep(0); }
 	FunctionCast(IOAudioEngineUserClient_performWatchdogOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performWatchdogOutput)(that, clientBufferSet, generationCount);
-	atomic_fetch_sub_explicit(&outputCounter, 1, memory_order_release);
+	atomic_flag_clear_explicit(&busy, memory_order_release);
 }
 
 void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size)

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -1,8 +1,8 @@
 //
-//  kern_bt4lefx.cpp
-//  BT4LEContinuityFixup
+//  kern_hooks.cpp
+//  SMCDellSensors
 //
-//  Copyright © 2017 lvs1974. All rights reserved.
+//  Copyright © 2020 lvs1974. All rights reserved.
 //
 
 #include <Headers/kern_api.hpp>

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -38,7 +38,7 @@ void KERNELHOOKS::deinit()
 
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) {}
+	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) { IOSleep(0); }
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientOutput)(that, firstSampleFrame, loopCount, bufferSet, sampleIntervalHi, sampleIntervalLo);
 	atomic_flag_clear_explicit(&busy, memory_order_release);
@@ -47,7 +47,7 @@ IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UI
 
 void KERNELHOOKS::IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount)
 {
-	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) {}
+	while (atomic_flag_test_and_set_explicit(&busy, memory_order_acquire)) { IOSleep(0); }
 	FunctionCast(IOAudioEngineUserClient_performWatchdogOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performWatchdogOutput)(that, clientBufferSet, generationCount);
 	atomic_flag_clear_explicit(&busy, memory_order_release);

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -57,7 +57,7 @@ void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_addr
 {
 	if (kextIOAudio.loadIndex == index) {
 		DBGLOG("sdell", "%s", kextIOAudio.id);
-				
+
 		KernelPatcher::RouteRequest requests[] {
 			{"__ZN23IOAudioEngineUserClient19performClientOutputEjjP22IOAudioClientBufferSetjj", IOAudioEngineUserClient_performClientOutput, orgIOAudioEngineUserClient_performClientOutput},
 			{"__ZN23IOAudioEngineUserClient21performWatchdogOutputEP22IOAudioClientBufferSetj", IOAudioEngineUserClient_performWatchdogOutput, orgIOAudioEngineUserClient_performWatchdogOutput}

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -9,18 +9,22 @@
 #include <Headers/kern_util.hpp>
 
 #include "kern_hooks.hpp"
+#include "SMIMonitor.hpp"
 
 static KERNELHOOKS *callbackKERNELHOOKS = nullptr;
+_Atomic(bool) volatile KERNELHOOKS::audioSamplesAvailable = false;
 
-static const char *kextIOBluetoothFamily[] { "/System/Library/Extensions/IOBluetoothFamily.kext/Contents/MacOS/IOBluetoothFamily" };
+static const char *kextIOAudioFamily[] { "/System/Library/Extensions/IOAudioFamily.kext/Contents/MacOS/IOAudioFamily" };
 
-static KernelPatcher::KextInfo kextIOBluetooth { "com.apple.iokit.IOBluetoothFamily", kextIOBluetoothFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded };
+static KernelPatcher::KextInfo kextIOAudio { "com.apple.iokit.IOAudioFamily", kextIOAudioFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded };
 
 bool KERNELHOOKS::init()
 {
+	DBGLOG("sdell", "KERNELHOOKS::init is called");
+	
 	callbackKERNELHOOKS = this;
 
-	lilu.onKextLoadForce(&kextIOBluetooth, 1,
+	lilu.onKextLoadForce(&kextIOAudio, 1,
 	[](void *user, KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 		callbackKERNELHOOKS->processKext(patcher, index, address, size);
 	}, this);
@@ -32,35 +36,33 @@ void KERNELHOOKS::deinit()
 {
 }
 
-int KERNELHOOKS::AppleBroadcomBluetoothHostController_SetControllerFeatureFlags(void *that, unsigned int)
+IOReturn KERNELHOOKS::IOAudioStream_processOutputSamples(void *that, void *clientBuffer, UInt32 firstSampleFrame, UInt32 loopCount, bool samplesAvailable)
 {
-	DBGLOG("bt4lefx", "AppleBroadcomBluetoothHostController::SetControllerFeatureFlags is called");
-	int result = FunctionCast(AppleBroadcomBluetoothHostController_SetControllerFeatureFlags,
-							  callbackKERNELHOOKS->orgIOBluetoothHostController_SetControllerFeatureFlags)(that, 0x0F);
-	DBGLOG("bt4lefx", "IOBluetoothHostController::SetControllerFeatureFlags returned %d", result);
-
+	callbackKERNELHOOKS->audioSamplesAvailable = true;
+	int attempts = 20;
+	while (SMIMonitor::smmIsBeingRead && --attempts >= 0)
+		IOSleep(1);
+	int result = FunctionCast(IOAudioStream_processOutputSamples,
+							  callbackKERNELHOOKS->orgIOAudioStream_processOutputSamples)(that, clientBuffer, firstSampleFrame, loopCount, samplesAvailable);
+	callbackKERNELHOOKS->audioSamplesAvailable = samplesAvailable && (result == kIOReturnSuccess);
 	return result;
 }
 
 void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size)
 {
-	if (kextIOBluetooth.loadIndex == index) {
-		DBGLOG("bt4lefx", "%s", kextIOBluetooth.id);
-		
-		const char* symbol = (getKernelVersion() > KernelVersion::Yosemite) ?
-			"__ZN25IOBluetoothHostController25SetControllerFeatureFlagsEj" :
-			"__ZN24IOBluetoothHCIController25SetControllerFeatureFlagsEj";
-
+	if (kextIOAudio.loadIndex == index) {
+		DBGLOG("sdell", "%s", kextIOAudio.id);
+				
 		KernelPatcher::RouteRequest request {
-				symbol,
-				AppleBroadcomBluetoothHostController_SetControllerFeatureFlags,
-				orgIOBluetoothHostController_SetControllerFeatureFlags
+				"__ZN13IOAudioStream20processOutputSamplesEP19IOAudioClientBufferjjb",
+				IOAudioStream_processOutputSamples,
+				orgIOAudioStream_processOutputSamples
 		};
 		patcher.routeMultiple(index, &request, 1, address, size);
 		if (patcher.getError() == KernelPatcher::Error::NoError) {
-			DBGLOG("bt4lefx", "routed %s", symbol);
+			DBGLOG("sdell", "routed %s", "__ZN13IOAudioStream20processOutputSamplesEP19IOAudioClientBufferjjb");
 		} else {
-			SYSLOG("bt4lefx", "failed to resolve %s, error = %d", symbol, patcher.getError());
+			SYSLOG("sdell", "failed to resolve %s, error = %d", "__ZN13IOAudioStream20processOutputSamplesEP19IOAudioClientBufferjjb", patcher.getError());
 			patcher.clearError();
 		}
 	}

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -11,12 +11,15 @@
 #include "kern_hooks.hpp"
 #include "SMIMonitor.hpp"
 
+#include <IOKit/IOTimerEventSource.h>
+
 static KERNELHOOKS *callbackKERNELHOOKS = nullptr;
 _Atomic(uint32_t) KERNELHOOKS::active_output = 0;
 
 static const char *kextIOAudioFamily[]     { "/System/Library/Extensions/IOAudioFamily.kext/Contents/MacOS/IOAudioFamily" };
 static const char *kextIOBluetoothFamily[] { "/System/Library/Extensions/IOBluetoothFamily.kext/Contents/MacOS/IOBluetoothFamily" };
 static constexpr size_t kextListSize {2};
+static constexpr uint32_t delay = 8;
 static KernelPatcher::KextInfo kextList[kextListSize] {
 	{ "com.apple.iokit.IOAudioFamily", kextIOAudioFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded },
 	{ "com.apple.iokit.IOBluetoothFamily", kextIOBluetoothFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded}
@@ -40,9 +43,15 @@ void KERNELHOOKS::deinit()
 {
 }
 
+void KERNELHOOKS::activateTimer()
+{
+	if (callbackKERNELHOOKS && callbackKERNELHOOKS->eventTimer)
+		callbackKERNELHOOKS->eventTimer->setTimeoutMS(delay);
+}
+
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientOutput)(that, firstSampleFrame, loopCount, bufferSet, sampleIntervalHi, sampleIntervalLo);
@@ -53,7 +62,7 @@ IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientOutput(void *that, UI
 
 void KERNELHOOKS::IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	FunctionCast(IOAudioEngineUserClient_performWatchdogOutput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performWatchdogOutput)(that, clientBufferSet, generationCount);
@@ -63,7 +72,7 @@ void KERNELHOOKS::IOAudioEngineUserClient_performWatchdogOutput(void *that, void
 
 IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientInput(void *that, UInt32 firstSampleFrame, void *bufferSet)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	IOReturn result = FunctionCast(IOAudioEngineUserClient_performClientInput,
 							  callbackKERNELHOOKS->orgIOAudioEngineUserClient_performClientInput)(that, firstSampleFrame, bufferSet);
@@ -74,7 +83,7 @@ IOReturn KERNELHOOKS::IOAudioEngineUserClient_performClientInput(void *that, UIn
 
 int64_t KERNELHOOKS::IOBluetoothDevice_moreIncomingData(void *that, void *arg1, unsigned int arg2)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	int64_t result = FunctionCast(IOBluetoothDevice_moreIncomingData,
 							  callbackKERNELHOOKS->orgIOBluetoothDevice_moreIncomingData)(that, arg1, arg2);
@@ -85,54 +94,83 @@ int64_t KERNELHOOKS::IOBluetoothDevice_moreIncomingData(void *that, void *arg1, 
 
 int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_writeWL(void *that, void *arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_writeWL,
 							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_writeWL)(that, arg1, arg2, arg3, arg4);
-	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+	// called method will call finally IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent (if result is KERN_SUCCESS)
+	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
 		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
 
 int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_writeOOLWL(void *that, uint64_t arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_writeOOLWL,
 							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_writeOOLWL)(that, arg1, arg2, arg3, arg4);
-	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+	// called method will call finally IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent (if result is KERN_SUCCESS)
+	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
 		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
 
 int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap(void *that, void *arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	atomic_fetch_add_explicit(&active_output, 1, memory_order_release);
 
 	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap,
 							  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap)(that, arg1, arg2, arg3, arg4);
 	// called method will call finally IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent (if result is KERN_SUCCESS)
-	if (result != KERN_SUCCESS)
-	{
-		if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
-			atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
-	}
+	if (result != KERN_SUCCESS && atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
 
 int64_t KERNELHOOKS::IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent(void *that, IOService *service, void *channel, int arg1, uint64_t arg2, uint64_t arg3)
 {
-	while (atomic_load_explicit(&SMIMonitor::busy._Value, memory_order_acquire)) ;
+	while (atomic_load_explicit(&SMIMonitor::busy, memory_order_acquire)) ;
 	int64_t result = FunctionCast(IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent,
 								  callbackKERNELHOOKS->orgIOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent)(that, service, channel, arg1, arg2, arg3);
-	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+	if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire) == 1)
+		activateTimer();
+	else if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
 		atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
 	return result;
 }
 
 void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size)
 {
+	if (!eventTimer) {
+		if (!workLoop)
+			workLoop = IOWorkLoop::workLoop();
+		
+		if (workLoop) {
+			eventTimer = IOTimerEventSource::timerEventSource(workLoop,
+			[](OSObject *owner, IOTimerEventSource *) {
+				if (atomic_load_explicit(&KERNELHOOKS::active_output, memory_order_acquire))
+					atomic_fetch_sub_explicit(&active_output, 1, memory_order_release);
+			});
+			
+			if (eventTimer) {
+				IOReturn result = workLoop->addEventSource(eventTimer);
+				if (result != kIOReturnSuccess) {
+					SYSLOG("sdell", "addEventSource failed");
+					OSSafeReleaseNULL(eventTimer);
+				}
+			}
+			else
+				SYSLOG("sdell", "timerEventSource failed");
+		}
+		else
+			SYSLOG("sdell", "IOService instance does not have workLoop");
+	}
+	
+	if (!eventTimer || !workLoop)
+		return;
+	
 	if (kextList[0].loadIndex == index) {
 		SYSLOG("sdell", "%s", kextList[0].id);
 

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -1,0 +1,67 @@
+//
+//  kern_bt4lefx.cpp
+//  BT4LEContinuityFixup
+//
+//  Copyright © 2017 lvs1974. All rights reserved.
+//
+
+#include <Headers/kern_api.hpp>
+#include <Headers/kern_util.hpp>
+
+#include "kern_hooks.hpp"
+
+static KERNELHOOKS *callbackKERNELHOOKS = nullptr;
+
+static const char *kextIOBluetoothFamily[] { "/System/Library/Extensions/IOBluetoothFamily.kext/Contents/MacOS/IOBluetoothFamily" };
+
+static KernelPatcher::KextInfo kextIOBluetooth { "com.apple.iokit.IOBluetoothFamily", kextIOBluetoothFamily, 1, {true, true}, {}, KernelPatcher::KextInfo::Unloaded };
+
+bool KERNELHOOKS::init()
+{
+	callbackKERNELHOOKS = this;
+
+	lilu.onKextLoadForce(&kextIOBluetooth, 1,
+	[](void *user, KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+		callbackKERNELHOOKS->processKext(patcher, index, address, size);
+	}, this);
+
+	return true;
+}
+
+void KERNELHOOKS::deinit()
+{
+}
+
+int KERNELHOOKS::AppleBroadcomBluetoothHostController_SetControllerFeatureFlags(void *that, unsigned int)
+{
+	DBGLOG("bt4lefx", "AppleBroadcomBluetoothHostController::SetControllerFeatureFlags is called");
+	int result = FunctionCast(AppleBroadcomBluetoothHostController_SetControllerFeatureFlags,
+							  callbackKERNELHOOKS->orgIOBluetoothHostController_SetControllerFeatureFlags)(that, 0x0F);
+	DBGLOG("bt4lefx", "IOBluetoothHostController::SetControllerFeatureFlags returned %d", result);
+
+	return result;
+}
+
+void KERNELHOOKS::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size)
+{
+	if (kextIOBluetooth.loadIndex == index) {
+		DBGLOG("bt4lefx", "%s", kextIOBluetooth.id);
+		
+		const char* symbol = (getKernelVersion() > KernelVersion::Yosemite) ?
+			"__ZN25IOBluetoothHostController25SetControllerFeatureFlagsEj" :
+			"__ZN24IOBluetoothHCIController25SetControllerFeatureFlagsEj";
+
+		KernelPatcher::RouteRequest request {
+				symbol,
+				AppleBroadcomBluetoothHostController_SetControllerFeatureFlags,
+				orgIOBluetoothHostController_SetControllerFeatureFlags
+		};
+		patcher.routeMultiple(index, &request, 1, address, size);
+		if (patcher.getError() == KernelPatcher::Error::NoError) {
+			DBGLOG("bt4lefx", "routed %s", symbol);
+		} else {
+			SYSLOG("bt4lefx", "failed to resolve %s, error = %d", symbol, patcher.getError());
+			patcher.clearError();
+		}
+	}
+}

--- a/Sensors/SMCDellSensors/kern_hooks.cpp
+++ b/Sensors/SMCDellSensors/kern_hooks.cpp
@@ -48,7 +48,7 @@ bool KERNELHOOKS::areAudioSamplesAvailable()
 		clock_get_uptime(&cur_time);
 		SUB_ABSOLUTETIME(&cur_time, &last_audio_event);
 		absolutetime_to_nanoseconds(cur_time, &nsecs);
-		if (nsecs > 3500000000) {
+		if (nsecs > 10000000000) {
 			audioSamplesAvailable = false;
 			last_audio_event = 0;
 		}

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -17,7 +17,7 @@ public:
 	void deinit();
 
 	/**
-	 *  Boolean flag is set to true if audio data are being out
+	 *  Atomic flag is used for mutual exlusion of audio output and smm access
 	 */
 	static atomic_flag busy;
 

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -9,13 +9,21 @@
 #define kern_hooks_hpp
 
 #include <Headers/kern_patcher.hpp>
+#include <stdatomic.h>
 
 class KERNELHOOKS {
 public:
 	bool init();
 	void deinit();
-	
+		
+		
+	/**
+	 *  Flag is set to true if any audio samples are available
+	 */
+	static _Atomic(bool) volatile audioSamplesAvailable;
+
 private:
+	
 	/**
 	 *  Patch kext if needed and prepare other patches
 	 *
@@ -29,12 +37,12 @@ private:
 	/**
 	 *  Hooked methods / callbacks
 	 */
-	static int AppleBroadcomBluetoothHostController_SetControllerFeatureFlags(void *that, unsigned int a2);
+	static IOReturn IOAudioStream_processOutputSamples(void *that, void *clientBuffer, UInt32 firstSampleFrame, UInt32 loopCount, bool samplesAvailable);
 
 	/**
 	 *  Original method
 	 */
-	mach_vm_address_t orgIOBluetoothHostController_SetControllerFeatureFlags {};
+	mach_vm_address_t orgIOAudioStream_processOutputSamples {};
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -17,9 +17,9 @@ public:
 	void deinit();
 
 	/**
-	 *  Returns true if there are any audio samples to play
+	 *  Boolean flag is set to true if audio data are being out
 	 */
-	static bool areAudioSamplesAvailable();
+	static atomic_flag busy;
 
 private:
 
@@ -43,15 +43,8 @@ private:
 	/**
 	 *  Original method
 	 */
-	mach_vm_address_t orgIOAudioStream_processOutputSamples {};
 	mach_vm_address_t orgIOAudioEngineUserClient_performClientOutput {};
 	mach_vm_address_t orgIOAudioEngineUserClient_performWatchdogOutput {};
-
-	/**
-	 *  Flag is set to true if any audio samples are available
-	 */
-	static _Atomic(uint32_t) outputCounter;
-	static _Atomic(AbsoluteTime) last_audio_event;
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -36,17 +36,20 @@ private:
 	/**
 	 *  Hooked methods / callbacks
 	 */
-	static IOReturn IOAudioStream_processOutputSamples(void *that, void *clientBuffer, UInt32 firstSampleFrame, UInt32 loopCount, bool samplesAvailable);
-
+	static IOReturn IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo);
+	
+	static void IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount);
+	
 	/**
 	 *  Original method
 	 */
 	mach_vm_address_t orgIOAudioStream_processOutputSamples {};
+	mach_vm_address_t orgIOAudioEngineUserClient_performClientOutput {};
+	mach_vm_address_t orgIOAudioEngineUserClient_performWatchdogOutput {};
 
 	/**
 	 *  Flag is set to true if any audio samples are available
 	 */
-	static _Atomic(bool) tempLock;
 	static _Atomic(uint32_t) outputCounter;
 	static _Atomic(AbsoluteTime) last_audio_event;
 };

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -40,11 +40,14 @@ private:
 	
 	static void IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount);
 	
+	static IOReturn IOAudioEngineUserClient_performClientInput(void *that, UInt32 firstSampleFrame, void *bufferSet);
+	
 	/**
 	 *  Original method
 	 */
 	mach_vm_address_t orgIOAudioEngineUserClient_performClientOutput {};
 	mach_vm_address_t orgIOAudioEngineUserClient_performWatchdogOutput {};
+	mach_vm_address_t orgIOAudioEngineUserClient_performClientInput {};
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -16,7 +16,9 @@ public:
 	bool init();
 	void deinit();
 
-
+	/**
+	 *  Returns true if there are any audio samples to play
+	 */
 	static bool areAudioSamplesAvailable();
 
 private:
@@ -44,10 +46,9 @@ private:
 	/**
 	 *  Flag is set to true if any audio samples are available
 	 */
-	static _Atomic(bool) volatile audioSamplesAvailable;
-	static _Atomic(bool) volatile tempLock;
-	static _Atomic(uint32_t) volatile outputCounter;
-	
+	static _Atomic(bool) tempLock;
+	static _Atomic(bool) audioSamplesAvailable;
+	static _Atomic(uint32_t) outputCounter;
 	static AbsoluteTime last_audio_event;
 };
 

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -1,8 +1,8 @@
 //
-//  kern_bt4lefx.hpp
-//  BT4LEContinuityFixup
+//  kern_hooks.hpp
+//  SMCDellSensord
 //
-//  Copyright © 2017 lvs1974. All rights reserved.
+//  Copyright © 2020 lvs1974. All rights reserved.
 //
 
 #ifndef kern_hooks_hpp
@@ -15,19 +15,12 @@ class KERNELHOOKS {
 public:
 	bool init();
 	void deinit();
-		
-		
+
+
 	static bool areAudioSamplesAvailable();
-	
-	/**
-	 *  Flag is set to true if any audio samples are available
-	 */
-	static _Atomic(bool) volatile audioSamplesAvailable;
-	
-	static AbsoluteTime last_audio_event;
 
 private:
-	
+
 	/**
 	 *  Patch kext if needed and prepare other patches
 	 *
@@ -47,6 +40,13 @@ private:
 	 *  Original method
 	 */
 	mach_vm_address_t orgIOAudioStream_processOutputSamples {};
+
+	/**
+	 *  Flag is set to true if any audio samples are available
+	 */
+	static _Atomic(bool) volatile audioSamplesAvailable;
+	
+	static AbsoluteTime last_audio_event;
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -47,9 +47,8 @@ private:
 	 *  Flag is set to true if any audio samples are available
 	 */
 	static _Atomic(bool) tempLock;
-	static _Atomic(bool) audioSamplesAvailable;
 	static _Atomic(uint32_t) outputCounter;
-	static AbsoluteTime last_audio_event;
+	static _Atomic(AbsoluteTime) last_audio_event;
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -1,0 +1,40 @@
+//
+//  kern_bt4lefx.hpp
+//  BT4LEContinuityFixup
+//
+//  Copyright © 2017 lvs1974. All rights reserved.
+//
+
+#ifndef kern_hooks_hpp
+#define kern_hooks_hpp
+
+#include <Headers/kern_patcher.hpp>
+
+class KERNELHOOKS {
+public:
+	bool init();
+	void deinit();
+	
+private:
+	/**
+	 *  Patch kext if needed and prepare other patches
+	 *
+	 *  @param patcher KernelPatcher instance
+	 *  @param index   kinfo handle
+	 *  @param address kinfo load address
+	 *  @param size    kinfo memory size
+	 */
+	void processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
+
+	/**
+	 *  Hooked methods / callbacks
+	 */
+	static int AppleBroadcomBluetoothHostController_SetControllerFeatureFlags(void *that, unsigned int a2);
+
+	/**
+	 *  Original method
+	 */
+	mach_vm_address_t orgIOBluetoothHostController_SetControllerFeatureFlags {};
+};
+
+#endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -10,6 +10,7 @@
 
 #include <Headers/kern_patcher.hpp>
 #include <stdatomic.h>
+#include <IOKit/IOService.h>
 
 class KERNELHOOKS {
 public:
@@ -19,7 +20,7 @@ public:
 	/**
 	 *  Atomic flag is used for mutual exlusion of audio output and smm access
 	 */
-	static atomic_flag busy;
+	static _Atomic(uint32_t) active_output;
 
 private:
 
@@ -37,17 +38,34 @@ private:
 	 *  Hooked methods / callbacks
 	 */
 	static IOReturn IOAudioEngineUserClient_performClientOutput(void *that, UInt32 firstSampleFrame, UInt32 loopCount, void *bufferSet, UInt32 sampleIntervalHi, UInt32 sampleIntervalLo);
-	
+
 	static void IOAudioEngineUserClient_performWatchdogOutput(void *that, void *clientBufferSet, UInt32 generationCount);
-	
+
 	static IOReturn IOAudioEngineUserClient_performClientInput(void *that, UInt32 firstSampleFrame, void *bufferSet);
-	
+
+
+	static int64_t IOBluetoothDevice_moreIncomingData(void *that, void *arg1, unsigned int arg2);
+
+	static int64_t IOBluetoothL2CAPChannelUserClient_writeWL(void *that, void *arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4);
+
+	static int64_t IOBluetoothL2CAPChannelUserClient_writeOOLWL(void *that, uint64_t arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4);
+
+	static int64_t IOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap(void *that, void *arg1, uint16_t arg2, uint64_t arg3, uint64_t arg4);
+
+	static int64_t IOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent(void *that, IOService *service, void *channel, int arg1, uint64_t arg2, uint64_t arg3);
 	/**
 	 *  Original method
 	 */
 	mach_vm_address_t orgIOAudioEngineUserClient_performClientOutput {};
 	mach_vm_address_t orgIOAudioEngineUserClient_performWatchdogOutput {};
 	mach_vm_address_t orgIOAudioEngineUserClient_performClientInput {};
+	
+	mach_vm_address_t orgIOBluetoothDevice_moreIncomingData {};
+	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_writeWL {};
+	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_writeOOLWL {};
+	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap {};
+	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_TrapWL {};
+	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent {};
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -45,6 +45,8 @@ private:
 	 *  Flag is set to true if any audio samples are available
 	 */
 	static _Atomic(bool) volatile audioSamplesAvailable;
+	static _Atomic(bool) volatile tempLock;
+	static _Atomic(uint32_t) volatile outputCounter;
 	
 	static AbsoluteTime last_audio_event;
 };

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -17,10 +17,14 @@ public:
 	void deinit();
 		
 		
+	static bool areAudioSamplesAvailable();
+	
 	/**
 	 *  Flag is set to true if any audio samples are available
 	 */
 	static _Atomic(bool) volatile audioSamplesAvailable;
+	
+	static AbsoluteTime last_audio_event;
 
 private:
 	

--- a/Sensors/SMCDellSensors/kern_hooks.hpp
+++ b/Sensors/SMCDellSensors/kern_hooks.hpp
@@ -20,7 +20,9 @@ public:
 	/**
 	 *  Atomic flag is used for mutual exlusion of audio output and smm access
 	 */
-	static _Atomic(uint32_t) active_output;
+	static atomic_uint active_output;
+	
+	static void activateTimer();
 
 private:
 
@@ -66,6 +68,9 @@ private:
 	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_Trap {};
 	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_WriteAsyncAudioData_TrapWL {};
 	mach_vm_address_t orgIOBluetoothL2CAPChannelUserClient_callBackAfterDataIsSent {};
+	
+	IOWorkLoop *workLoop {};
+	IOTimerEventSource *eventTimer {};
 };
 
 #endif /* kern_hooks_hpp */

--- a/Sensors/SMCDellSensors/kern_start.cpp
+++ b/Sensors/SMCDellSensors/kern_start.cpp
@@ -1,0 +1,42 @@
+//
+//  kern_start.cpp
+//  SMCDellSensors
+//
+//  Copyright © 2017 lvs1974. All rights reserved.
+//
+
+#include <Headers/plugin_start.hpp>
+#include <Headers/kern_api.hpp>
+
+#include "kern_hooks.hpp"
+
+static KERNELHOOKS kernhooks;
+
+static const char *bootargOff[] {
+	"-sdelloff"
+};
+
+static const char *bootargDebug[] {
+	"-sdelldbg"
+};
+
+static const char *bootargBeta[] {
+	"-sdellbeta"
+};
+
+PluginConfiguration ADDPR(config) {
+	xStringify(PRODUCT_NAME),
+	parseModuleVersion(xStringify(MODULE_VERSION)),
+	LiluAPI::AllowNormal | LiluAPI::AllowInstallerRecovery | LiluAPI::AllowSafeMode,
+	bootargOff,
+	arrsize(bootargOff),
+	bootargDebug,
+	arrsize(bootargDebug),
+	bootargBeta,
+	arrsize(bootargBeta),
+	KernelVersion::MountainLion,
+	KernelVersion::BigSur,
+	[]() {
+		kernhooks.init();
+	}
+};

--- a/Sensors/SMCDellSensors/kern_start.cpp
+++ b/Sensors/SMCDellSensors/kern_start.cpp
@@ -10,7 +10,7 @@
 
 #include "kern_hooks.hpp"
 
-static KERNELHOOKS kernhooks;
+KERNELHOOKS hooks;
 
 static const char *bootargOff[] {
 	"-sdelloff"
@@ -37,6 +37,6 @@ PluginConfiguration ADDPR(config) {
 	KernelVersion::MountainLion,
 	KernelVersion::BigSur,
 	[]() {
-		kernhooks.init();
+		hooks.init();
 	}
 };

--- a/Sensors/SMCDellSensors/kern_start.cpp
+++ b/Sensors/SMCDellSensors/kern_start.cpp
@@ -2,7 +2,7 @@
 //  kern_start.cpp
 //  SMCDellSensors
 //
-//  Copyright © 2017 lvs1974. All rights reserved.
+//  Copyright © 2020 lvs1974. All rights reserved.
 //
 
 #include <Headers/plugin_start.hpp>

--- a/VirtualSMC.xcodeproj/project.pbxproj
+++ b/VirtualSMC.xcodeproj/project.pbxproj
@@ -82,6 +82,10 @@
 		CEC803821FFC8BFA008544A7 /* kern_intrs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = CEC803801FFC8BFA008544A7 /* kern_intrs.hpp */; };
 		CED5DBE820AAB6E6001FE8CF /* kern_efiend.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CED5DBE720AAB6E6001FE8CF /* kern_efiend.cpp */; };
 		DF412897249556C70071334F /* SSDT-BATC.dsl in Resources */ = {isa = PBXBuildFile; fileRef = DF412896249556C60071334F /* SSDT-BATC.dsl */; };
+		F61454732527962900A84C06 /* kern_hooks.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6145471252794DE00A84C06 /* kern_hooks.hpp */; };
+		F61454742527963E00A84C06 /* kern_hooks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6145472252794DF00A84C06 /* kern_hooks.cpp */; };
+		F61454752527963E00A84C06 /* kern_start.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F61454702527945C00A84C06 /* kern_start.cpp */; };
+		F63CAF8725279FFB00D22631 /* plugin_start.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE405ED81E4A080700AA0B3D /* plugin_start.cpp */; };
 		F68156982496B4AC007C21AD /* SMCDellSensors.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F68156962496B235007C21AD /* SMCDellSensors.hpp */; };
 		F68156992496B4C4007C21AD /* SMCDellSensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F68156972496B235007C21AD /* SMCDellSensors.cpp */; };
 		F681569A2496B572007C21AD /* KeyImplementations.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F68156872496B0BC007C21AD /* KeyImplementations.hpp */; };
@@ -393,6 +397,9 @@
 		CED5DBE720AAB6E6001FE8CF /* kern_efiend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_efiend.cpp; sourceTree = "<group>"; };
 		CEF2169D216937F200378E02 /* AppleSmc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppleSmc.h; sourceTree = "<group>"; };
 		DF412896249556C60071334F /* SSDT-BATC.dsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "SSDT-BATC.dsl"; path = "Docs/SSDT-BATC.dsl"; sourceTree = "<group>"; };
+		F61454702527945C00A84C06 /* kern_start.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = kern_start.cpp; sourceTree = "<group>"; };
+		F6145471252794DE00A84C06 /* kern_hooks.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = kern_hooks.hpp; sourceTree = "<group>"; };
+		F6145472252794DF00A84C06 /* kern_hooks.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = kern_hooks.cpp; sourceTree = "<group>"; };
 		F68156842496AFCF007C21AD /* SMCDellSensors.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SMCDellSensors.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		F68156872496B0BC007C21AD /* KeyImplementations.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = KeyImplementations.hpp; sourceTree = "<group>"; };
 		F68156902496B0BC007C21AD /* KeyImplementations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyImplementations.cpp; sourceTree = "<group>"; };
@@ -821,6 +828,9 @@
 		F68156862496B0BC007C21AD /* SMCDellSensors */ = {
 			isa = PBXGroup;
 			children = (
+				F6145472252794DF00A84C06 /* kern_hooks.cpp */,
+				F6145471252794DE00A84C06 /* kern_hooks.hpp */,
+				F61454702527945C00A84C06 /* kern_start.cpp */,
 				F68156A02498FD28007C21AD /* SMIState.hpp */,
 				F681569D2496B624007C21AD /* SMIMonitor.cpp */,
 				F681569C2496B624007C21AD /* SMIMonitor.hpp */,
@@ -902,6 +912,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F61454732527962900A84C06 /* kern_hooks.hpp in Headers */,
 				F68156A12498FD42007C21AD /* SMIState.hpp in Headers */,
 				F681569E2496B640007C21AD /* SMIMonitor.hpp in Headers */,
 				F681569A2496B572007C21AD /* KeyImplementations.hpp in Headers */,
@@ -1416,6 +1427,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F63CAF8725279FFB00D22631 /* plugin_start.cpp in Sources */,
+				F61454742527963E00A84C06 /* kern_hooks.cpp in Sources */,
+				F61454752527963E00A84C06 /* kern_start.cpp in Sources */,
 				F681569F2496B649007C21AD /* SMIMonitor.cpp in Sources */,
 				F681569B2496B581007C21AD /* KeyImplementations.cpp in Sources */,
 				F68156992496B4C4007C21AD /* SMCDellSensors.cpp in Sources */,
@@ -2916,6 +2930,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"MODULE_VERSION=$(MODULE_VERSION)",
 					"PRODUCT_NAME=$(PRODUCT_NAME)",
+					"LILU_CUSTOM_IOKIT_INIT=1",
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = (
@@ -2968,6 +2983,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"MODULE_VERSION=$(MODULE_VERSION)",
 					"PRODUCT_NAME=$(PRODUCT_NAME)",
+					"LILU_CUSTOM_IOKIT_INIT=1",
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = (
@@ -3021,6 +3037,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"MODULE_VERSION=$(MODULE_VERSION)",
 					"PRODUCT_NAME=$(PRODUCT_NAME)",
+					"LILU_CUSTOM_IOKIT_INIT=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${PROJECT_DIR}/Lilu.kext/Contents/Resources",


### PR DESCRIPTION
Here is my next attempt to reduce audio lags.
Idea: hook method IOAudioStream::processOutputSamples(IOAudioStream *this, void *clientBuffer, UInt32 firstSampleFrame, UInt32 loopCount, bool samplesAvailable) and do not read SMM while there are any processed audio samples.