### PR TITLE
Forcing publish temperature when supplement info is not available 

### DIFF
--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -155,6 +155,9 @@ bool ACPIBattery::getBatteryInfo(BatteryInfo &bi, bool extended) {
 					if (!(supplementConfig & (1U << BSSTemperatureSMBusOnly)))
 						bi.state.publishTemperatureKey = true;
 				}
+			} else {
+				// forcing show temperature
+				bi.state.publishTemperatureKey = true;
 			}
 			supplement->release();
 		}

--- a/Sensors/SMCBatteryManager/ACPIBattery.cpp
+++ b/Sensors/SMCBatteryManager/ACPIBattery.cpp
@@ -89,6 +89,8 @@ bool ACPIBattery::getBatteryInfo(BatteryInfo &bi, bool extended) {
 		supplementConfig = 0;
 		if (device->evaluateObject(AcpiBatteryInfoSup, &supplement) != kIOReturnSuccess) {
 			DBGLOG("acpib", "supplement info not available");
+			//Force publish temperature when supplement info not available
+			bi.state.publishTemperatureKey = true;
 		} else {
 			OSArray *extra = OSDynamicCast(OSArray, supplement);
 			if (extra) {
@@ -155,9 +157,6 @@ bool ACPIBattery::getBatteryInfo(BatteryInfo &bi, bool extended) {
 					if (!(supplementConfig & (1U << BSSTemperatureSMBusOnly)))
 						bi.state.publishTemperatureKey = true;
 				}
-			} else {
-				// forcing show temperature
-				bi.state.publishTemperatureKey = true;
 			}
 			supplement->release();
 		}


### PR DESCRIPTION
Fix missing sensor
![photo_2020-12-14 22 57 46](https://user-images.githubusercontent.com/5329826/102140656-e0d80200-3e5f-11eb-963a-f0fec5931b5a.jpeg)
after 
![temp show](https://user-images.githubusercontent.com/5329826/102140830-27c5f780-3e60-11eb-981b-ba3489e4ca21.png)

with kext previous this pr https://github.com/acidanthera/VirtualSMC/pull/47 , cpu and igpu temperatures were read on ice lake
the temperatures in question were no longer read, with my modification they return to being read