### PR TITLE
Add HP Pavilion 15-cb Fans

### DIFF
--- a/Docs/EmbeddedControllers.md
+++ b/Docs/EmbeddedControllers.md
@@ -485,6 +485,19 @@ Field (ERAM, ByteAcc, NoLock, Preserve)
 
 _Note_: Found and tested by @1alessandro1. Only one fan header exists, so both fans will be reported in sync as a single fan as shown [here](https://github.com/acidanthera/bugtracker/issues/395#issuecomment-808756416).
 
+### HP Pavilion 15-cb073tx (`generic`)
+
+- `ec-device` = `"generic"`
+- `fan-count` = `2`
+- `fan0-addr` = `0xB2`
+- `fan0-size` = `2`
+- `fan0-big` = `0`
+- `fan1-addr` = `0xC3`
+- `fan1-size` = `2`
+- `fan1-big` = `0`
+
+_Note_: Found and tested by @zty199, with @1alessandro1's help. EC RAM details are exactly the same as HP Pavilion 14 CE2072NL, but one more fan connector exists on the motherboard.
+
 <hr>
 
 (List compiled by @MacKonsti proudly assisting @vit9696)


### PR DESCRIPTION
Add HP Pavilion 15-cb073tx Fans, should work for HP-83XX motherboard.