### PR TITLE
ITE SuperIO fan control

### DIFF
--- a/Docs/SuperIOs.md
+++ b/Docs/SuperIOs.md
@@ -1,0 +1,30 @@
+## SMCSuperIO fan configuration
+SMCSuperIO can read fan speeds on ITE/Nuvoton/Winbond and set fan speeds on ITE. The default configuration often works but there can be issues such as fan speed controlling a different fan, set speed not matching or non-existent fans showing.
+
+You can find out how to configure this module here.
+
+`#` in the property name should be equal to the fan number displayed in your fan control software (eg. first fan = fan0, second fan = fan1). Hide non-existent fans last as doing it first will make it harder to figure out correct fan index.
+
+### fan#-hide
+Hides the fan when set to value 01 or above. Example `01` **MUST** be type **Data**.
+
+### fan#-control
+The control index to use for the fan, useful for fixing a different/non-existent fan being controlled when setting speed. By default it's equal to the fan index which works for some configurations. Example `02`, **MUST** be type **Data**.
+
+### fan#-pwm
+RPM to PWM curve. It can be automatically generated with tool `fanpwmgen`.
+
+```
+❯ ./fanpwmgen -h
+VirtualSMC fan#-pwm generation tool
+Usage:
+./fanpwmgen [options]
+    -f <num>   : the fan number to use
+    -s <steps> : number of steps to use when generating curve, default 16 and max 256
+    -t <time>  : time to wait before going to next step, default 2 seconds
+    -h         : help
+```
+
+Before running `fanpwmgen` you **MUST** make sure there is no `fan#-pwm` curve already set for that fan. Also **make sure all fan control software is closed**
+
+For example to generate a curve for fan #1 use `./fanpwmgen -f 1`. Once finished running it will output the fan curve after `fan#-pwm: ` which you can add to DeviceProperties. **MUST** be type **String**.

--- a/Sensors/SMCSuperIO/Devices.cpp
+++ b/Sensors/SMCSuperIO/Devices.cpp
@@ -876,6 +876,24 @@ public:
 
 };
 
+class Device_0x8689 final : public GeneratedITEDevice_6 {
+public:
+	static SuperIODevice *createDevice(uint16_t deviceId) {
+		if (deviceId == 0x8689)
+			return new Device_0x8689();
+		return nullptr;
+	}
+
+	uint8_t getLdn() override {
+		return 0x04;
+	}
+
+	const char* getModelName() override {
+		return "ITE IT8689E";
+	}
+
+};
+
 class Device_0x8795 final : public GeneratedITEDevice_6 {
 public:
 	static SuperIODevice *createDevice(uint16_t deviceId) {
@@ -3346,6 +3364,8 @@ SuperIODevice *createDeviceITE(uint16_t deviceId) {
 	device = Device_0x8792::createDevice(deviceId);
 	if (device) return device;
 	device = Device_0x8688::createDevice(deviceId);
+	if (device) return device;
+	device = Device_0x8689::createDevice(deviceId);
 	if (device) return device;
 	device = Device_0x8795::createDevice(deviceId);
 	if (device) return device;

--- a/Sensors/SMCSuperIO/ITEDevice.cpp
+++ b/Sensors/SMCSuperIO/ITEDevice.cpp
@@ -187,10 +187,6 @@ namespace ITE {
 		uint8_t pwm;
 		uint16_t rpm;
 
-		for (int i = 0; i < 256; ++i) _pwmCurve[index][i] = UINT16_MAX;
-
-		_pwmCurve[index][0] = 0;
-
 		while (true) {
 			split = strsep(&str, ";");
 
@@ -269,6 +265,12 @@ namespace ITE {
 			else
 				_fanControlIndex[index] = index;
 
+			// Set default PWM values
+			for (int i = 0; i < 256; ++i) _pwmCurve[index][i] = UINT16_MAX;
+
+			_pwmCurve[index][0] = 0;
+			_pwmCurve[index][255] = 3200;
+
 			// Set PWM curve
 			snprintf(name, sizeof(name), "fan%u-pwm", index);
 			auto nameP = lpc->getProperty(name);
@@ -277,10 +279,6 @@ namespace ITE {
 			if (nameData) {
 				nameVal = STRDUP(static_cast<const char *>(nameData->getBytesNoCopy()), nameData->getLength());
 				curveFromStr(index, nameVal);
-			} else {
-				// Set default value
-				_pwmCurve[index][0] = 0;
-				_pwmCurve[index][255] = 3200;
 			}
 			computeCurve(index);
 

--- a/Sensors/SMCSuperIO/ITEDevice.cpp
+++ b/Sensors/SMCSuperIO/ITEDevice.cpp
@@ -276,8 +276,6 @@ namespace ITE {
 			if (WIOKit::getOSDataValue<uint8_t>(lpc, name, tmp))
 				continue;
 
-			fanCount++;
-
 			// Set control index
 			snprintf(name, sizeof(name), "fan%u-control", index);
 			if (WIOKit::getOSDataValue<uint8_t>(lpc, name, tmp) && tmp <= getTachometerCount())
@@ -305,28 +303,32 @@ namespace ITE {
 			setMinValue(index, getCurveMin(index));
 			setMaxValue(index, getCurveMax(index));
 
+			// Use fanCount for key names, they will still use the proper index.
+			//
 			// Current speed
-			VirtualSMCAPI::addKey(KeyF0Ac(index), vsmcPlugin.data,
+			VirtualSMCAPI::addKey(KeyF0Ac(fanCount), vsmcPlugin.data,
 				VirtualSMCAPI::valueWithFp(0, SmcKeyTypeFpe2, new TachometerKey(getSmcSuperIO(), this, index), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
 
 			// We must add keys in alphabetical order
 			if (getLdn() != EC_ENDPOINT) {
 				// Enable manual control
-				VirtualSMCAPI::addKey(KeyF0Md(index), vsmcPlugin.data,
+				VirtualSMCAPI::addKey(KeyF0Md(fanCount), vsmcPlugin.data,
 				  VirtualSMCAPI::valueWithUint8(0, new ManualKey(getSmcSuperIO(), this, index), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
 			}
 			// Min speed
-			VirtualSMCAPI::addKey(KeyF0Mn(index), vsmcPlugin.data,
+			VirtualSMCAPI::addKey(KeyF0Mn(fanCount), vsmcPlugin.data,
 				VirtualSMCAPI::valueWithFp(0, SmcKeyTypeFpe2, new MinKey(getSmcSuperIO(), this, index), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
 			// Max speed
-			VirtualSMCAPI::addKey(KeyF0Mx(index), vsmcPlugin.data,
+			VirtualSMCAPI::addKey(KeyF0Mx(fanCount), vsmcPlugin.data,
 				VirtualSMCAPI::valueWithFp(0, SmcKeyTypeFpe2, new MaxKey(getSmcSuperIO(), this, index), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
 
 			if (getLdn() != EC_ENDPOINT) {
 				// Target speed
-				VirtualSMCAPI::addKey(KeyF0Tg(index), vsmcPlugin.data,
+				VirtualSMCAPI::addKey(KeyF0Tg(fanCount), vsmcPlugin.data,
 				  VirtualSMCAPI::valueWithFp(0, SmcKeyTypeFpe2, new TargetKey(getSmcSuperIO(), this, index), SMC_KEY_ATTRIBUTE_WRITE | SMC_KEY_ATTRIBUTE_READ));
 			}
+
+			fanCount++;
 		}
 
 		VirtualSMCAPI::addKey(KeyFNum, vsmcPlugin.data,

--- a/Sensors/SMCSuperIO/ITEDevice.cpp
+++ b/Sensors/SMCSuperIO/ITEDevice.cpp
@@ -12,6 +12,7 @@
 #include "Devices.hpp"
 
 namespace ITE {
+	uint8_t FAN_PWM_CTRL_REG[ITE_MAX_TACHOMETER_COUNT];
 	uint8_t _initialFanPwmControl[ITE_MAX_TACHOMETER_COUNT];
 	uint8_t _initialFanOutputModeEnabled[ITE_MAX_TACHOMETER_COUNT];
 	uint8_t _initialFanPwmControlExt[ITE_MAX_TACHOMETER_COUNT];
@@ -253,6 +254,10 @@ namespace ITE {
 				{
 					_hasExtReg = true;
 				}
+				if (strcmp(detectedDevice->getModelName(), "ITE IT8665E") || strcmp(detectedDevice->getModelName(), "ITE IT8625E")) {
+					lilu_os_memcpy(&FAN_PWM_CTRL_REG, &FAN_PWM_CTRL_REG_ALT, MAX_TACHOMETER_COUNT);
+				} else
+					lilu_os_memcpy(&FAN_PWM_CTRL_REG, &FAN_PWM_CTRL_REG_1, MAX_TACHOMETER_COUNT);
 			}
 		}
 		leave(port);

--- a/Sensors/SMCSuperIO/ITEDevice.cpp
+++ b/Sensors/SMCSuperIO/ITEDevice.cpp
@@ -208,7 +208,7 @@ namespace ITE {
 		uint16_t rpm;
 
 		while (true) {
-			split = strsep(&str, ";");
+			split = strsep(&str, "|");
 
 			if (!split)
 			  break;
@@ -298,7 +298,7 @@ namespace ITE {
 				curveFromStr(index, nameVal);
 			} else {
 				_pwmCurve[index][0] = 0;
-				_pwmCurve[index][255] = 3200;
+				_pwmCurve[index][255] = 3315;
 			}
 			computeCurve(index);
 

--- a/Sensors/SMCSuperIO/ITEDevice.hpp
+++ b/Sensors/SMCSuperIO/ITEDevice.hpp
@@ -14,14 +14,20 @@
 
 namespace ITE {
 	
-	static constexpr uint8_t ITE_MAX_TACHOMETER_COUNT = 5;
+	static constexpr uint8_t ITE_MAX_TACHOMETER_COUNT = 6;
 	static constexpr uint8_t ITE_MAX_VOLTAGE_COUNT = 9;
 
 	static constexpr uint8_t ITE_ADDRESS_REGISTER_OFFSET = 0x05;
 	static constexpr uint8_t ITE_DATA_REGISTER_OFFSET = 0x06;
 	static constexpr uint8_t ITE_FAN_TACHOMETER_DIVISOR_REGISTER = 0x0B;
-	static constexpr uint8_t ITE_FAN_TACHOMETER_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x0d, 0x0e, 0x0f, 0x80, 0x82 };
-	static constexpr uint8_t ITE_FAN_TACHOMETER_EXT_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x18, 0x19, 0x1a, 0x81, 0x83 };
+	static constexpr uint8_t FAN_MAIN_CTRL_REG = 0x13;
+
+	static constexpr uint8_t FAN_PWM_CTRL_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 };
+	static constexpr uint8_t FAN_PWM_CTRL_REG_2[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
+
+	static constexpr uint8_t FAN_PWM_CTRL_EXT_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x63, 0x6b, 0x73, 0x7b, 0xa3, 0xab };
+	static constexpr uint8_t ITE_FAN_TACHOMETER_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x0d, 0x0e, 0x0f, 0x80, 0x82, 0x4c };
+	static constexpr uint8_t ITE_FAN_TACHOMETER_EXT_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x18, 0x19, 0x1a, 0x81, 0x83, 0x4d };
 	static constexpr uint8_t ITE_VOLTAGE_REG[ITE_MAX_VOLTAGE_COUNT] = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28 };
 
 	// ITE Debugger interface for EC memory snooping. Refer to "EC Memory Snoop (ECMS)" section in datasheet.
@@ -72,6 +78,14 @@ namespace ITE {
 		uint16_t tachometerRead(uint8_t);
 		uint16_t tachometerRead8bit(uint8_t);
 		uint16_t tachometerReadEC(uint8_t);
+
+		void tachometerWrite(uint8_t index, uint8_t value, bool enabled);
+		void tachometerSaveDefault(uint8_t);
+		void tachometerRestoreDefault(uint8_t);
+		/**
+		 * This is a stub to keep the code generator happy since updateTargets is overridden.
+		 */
+		void updateTargets() override;
 
 		/**
 		 * Reads voltage data. Invoked from update() only.

--- a/Sensors/SMCSuperIO/ITEDevice.hpp
+++ b/Sensors/SMCSuperIO/ITEDevice.hpp
@@ -22,8 +22,8 @@ namespace ITE {
 	static constexpr uint8_t ITE_FAN_TACHOMETER_DIVISOR_REGISTER = 0x0B;
 	static constexpr uint8_t FAN_MAIN_CTRL_REG = 0x13;
 
-	static constexpr uint8_t FAN_PWM_CTRL_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 };
-	static constexpr uint8_t FAN_PWM_CTRL_REG_2[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
+	static constexpr uint8_t FAN_PWM_CTRL_REG_1[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
+	static constexpr uint8_t FAN_PWM_CTRL_REG_ALT[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 };
 
 	static constexpr uint8_t FAN_PWM_CTRL_EXT_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x63, 0x6b, 0x73, 0x7b, 0xa3, 0xab };
 	static constexpr uint8_t ITE_FAN_TACHOMETER_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x0d, 0x0e, 0x0f, 0x80, 0x82, 0x4c };

--- a/Sensors/SMCSuperIO/ITEDevice.hpp
+++ b/Sensors/SMCSuperIO/ITEDevice.hpp
@@ -22,7 +22,7 @@ namespace ITE {
 	static constexpr uint8_t ITE_FAN_TACHOMETER_DIVISOR_REGISTER = 0x0B;
 	static constexpr uint8_t FAN_MAIN_CTRL_REG = 0x13;
 
-	static constexpr uint8_t FAN_PWM_CTRL_REG_1[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
+	static uint8_t FAN_PWM_CTRL_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
 	static constexpr uint8_t FAN_PWM_CTRL_REG_ALT[ITE_MAX_TACHOMETER_COUNT] = { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 };
 
 	static constexpr uint8_t FAN_PWM_CTRL_EXT_REG[ITE_MAX_TACHOMETER_COUNT] = { 0x63, 0x6b, 0x73, 0x7b, 0xa3, 0xab };

--- a/Sensors/SMCSuperIO/SuperIODevice.cpp
+++ b/Sensors/SMCSuperIO/SuperIODevice.cpp
@@ -64,14 +64,14 @@ SMC_RESULT TachometerKey::readAccess() {
 }
 
 SMC_RESULT MinKey::readAccess() {
-	double val = 0;
+	double val = device->getMinValue(index);
 	const_cast<SMCSuperIO*>(sio)->quickReschedule();
 	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, val);
 	return SmcSuccess;
 }
 
 SMC_RESULT MaxKey::readAccess() {
-	double val = 3200;
+	double val = device->getMaxValue(index);
 	const_cast<SMCSuperIO*>(sio)->quickReschedule();
 	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, val);
 	return SmcSuccess;

--- a/Sensors/SMCSuperIO/SuperIODevice.cpp
+++ b/Sensors/SMCSuperIO/SuperIODevice.cpp
@@ -63,6 +63,54 @@ SMC_RESULT TachometerKey::readAccess() {
 	return SmcSuccess;
 }
 
+SMC_RESULT MinKey::readAccess() {
+	double val = 0;
+	const_cast<SMCSuperIO*>(sio)->quickReschedule();
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, val);
+	return SmcSuccess;
+}
+
+SMC_RESULT MaxKey::readAccess() {
+	double val = 3200;
+	const_cast<SMCSuperIO*>(sio)->quickReschedule();
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, val);
+	return SmcSuccess;
+}
+
+SMC_RESULT ManualKey::readAccess() {
+	uint8_t val = device->getManualValue(index);
+	const_cast<SMCSuperIO*>(sio)->quickReschedule();
+	*reinterpret_cast<uint8_t *>(data) = val;
+	return SmcSuccess;
+}
+
+SMC_RESULT ManualKey::update(const SMC_DATA *src) {
+	VirtualSMCValue::update(src);
+
+	UInt8 val = src[0];
+	device->setManualValue(index, val);
+	device->updateTargets();
+
+	return SmcSuccess;
+}
+
+SMC_RESULT TargetKey::readAccess() {
+	double val = device->getTargetValue(index);
+	const_cast<SMCSuperIO*>(sio)->quickReschedule();
+	*reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeIntFp(SmcKeyTypeFpe2, val);
+	return SmcSuccess;
+}
+
+SMC_RESULT TargetKey::update(const SMC_DATA *src) {
+	VirtualSMCValue::update(src);
+
+	auto val = VirtualSMCAPI::decodeIntFp(SmcKeyTypeFpe2, *reinterpret_cast<const uint16_t *>(src));;
+	device->setTargetValue(index, val);
+	device->updateTargets();
+
+	return SmcSuccess;
+}
+
 SMC_RESULT VoltageKey::readAccess() {
 	double val = device->getVoltageValue(index);
 	const_cast<SMCSuperIO*>(sio)->quickReschedule();

--- a/Sensors/SMCSuperIO/SuperIODevice.hpp
+++ b/Sensors/SMCSuperIO/SuperIODevice.hpp
@@ -90,7 +90,6 @@ protected:
 	static constexpr SMC_KEY KeyF0Mx(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'M','x'); }
 	static constexpr SMC_KEY KeyF0Md(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'M','d'); }
 	static constexpr SMC_KEY KeyF0Tg(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'T','g'); }
-	static constexpr SMC_KEY KeyF0Zz(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'Z','z'); }
 	static constexpr SMC_KEY KeyVM0R(size_t i) { return SMC_MAKE_IDENTIFIER('V','M',KeyIndexes[i],'R'); }
 	static constexpr SMC_KEY KeyVD0R(size_t i) { return SMC_MAKE_IDENTIFIER('V','D',KeyIndexes[i],'R'); }
 	static constexpr SMC_KEY KeyV50R(size_t i) { return SMC_MAKE_IDENTIFIER('V','5',KeyIndexes[i],'R'); }

--- a/Sensors/SMCSuperIO/SuperIODevice.hpp
+++ b/Sensors/SMCSuperIO/SuperIODevice.hpp
@@ -34,6 +34,14 @@ protected:
 	 */
 	_Atomic(uint16_t) tachometers[MAX_TACHOMETER_COUNT] = { };
 	/**
+	 *	Target RPMs
+	 */
+	_Atomic(uint16_t) targets[MAX_TACHOMETER_COUNT] = { };
+	/**
+	 * Manual contol
+	 */
+	_Atomic(uint8_t) manual[MAX_TACHOMETER_COUNT] = { };
+	/**
 	 *  Voltages
 	 */
 	_Atomic(float) voltages[MAX_VOLTAGE_COUNT] = { };
@@ -76,7 +84,13 @@ protected:
 	 *  Supported keys
 	 */
 	static constexpr SMC_KEY KeyFNum = SMC_MAKE_IDENTIFIER('F','N','u','m');
+	static constexpr SMC_KEY KeyF0ID(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'I','D'); }
 	static constexpr SMC_KEY KeyF0Ac(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'A', 'c'); }
+	static constexpr SMC_KEY KeyF0Mn(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'M','n'); }
+	static constexpr SMC_KEY KeyF0Mx(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'M','x'); }
+	static constexpr SMC_KEY KeyF0Md(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'M','d'); }
+	static constexpr SMC_KEY KeyF0Tg(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'T','g'); }
+	static constexpr SMC_KEY KeyF0Zz(size_t i) { return SMC_MAKE_IDENTIFIER('F', KeyIndexes[i],'Z','z'); }
 	static constexpr SMC_KEY KeyVM0R(size_t i) { return SMC_MAKE_IDENTIFIER('V','M',KeyIndexes[i],'R'); }
 	static constexpr SMC_KEY KeyVD0R(size_t i) { return SMC_MAKE_IDENTIFIER('V','D',KeyIndexes[i],'R'); }
 	static constexpr SMC_KEY KeyV50R(size_t i) { return SMC_MAKE_IDENTIFIER('V','5',KeyIndexes[i],'R'); }
@@ -223,12 +237,28 @@ public:
 	
 	void updateIORegistry();
 	
+	virtual void updateTargets() {};
+
 	/**
 	 *  Accessors
 	 */
 	uint16_t getTachometerValue(uint8_t index) {
 		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
 			return atomic_load_explicit(&tachometers[index], memory_order_relaxed);
+		}
+		return 0;
+	}
+
+	uint16_t getTargetValue(uint8_t index) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			return atomic_load_explicit(&targets[index], memory_order_relaxed);
+		}
+		return 0;
+	}
+
+	uint8_t getManualValue(uint8_t index) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			return atomic_load_explicit(&manual[index], memory_order_relaxed);
 		}
 		return 0;
 	}
@@ -257,6 +287,17 @@ public:
 	i386_ioport_t getDevicePort() { return devicePort; }
 	const SMCSuperIO* getSmcSuperIO() { return smcSuperIO; }
 
+	virtual void setTargetValue(uint8_t index, uint16_t value) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			atomic_store_explicit(&targets[index], value, memory_order_relaxed);
+		}
+	}
+
+	virtual void setManualValue(uint8_t index, uint8_t value) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			atomic_store_explicit(&manual[index], value, memory_order_relaxed);
+		}
+	}
 	/**
 	 *  Destructor
 	 */
@@ -274,6 +315,48 @@ protected:
 	SMC_RESULT readAccess() override;
 public:
 	TachometerKey(const SMCSuperIO *sio, SuperIODevice *device, uint8_t index) : sio(sio), index(index), device(device) {}
+};
+
+class MinKey : public VirtualSMCValue {
+protected:
+	const SMCSuperIO *sio;
+	uint8_t index;
+	SuperIODevice *device;
+	SMC_RESULT readAccess() override;
+public:
+	MinKey(const SMCSuperIO *sio, SuperIODevice *device, uint8_t index) : sio(sio), index(index), device(device) {}
+};
+
+class MaxKey : public VirtualSMCValue {
+protected:
+	const SMCSuperIO *sio;
+	uint8_t index;
+	SuperIODevice *device;
+	SMC_RESULT readAccess() override;
+public:
+	MaxKey(const SMCSuperIO *sio, SuperIODevice *device, uint8_t index) : sio(sio), index(index), device(device) {}
+};
+
+class ManualKey : public VirtualSMCValue {
+protected:
+	const SMCSuperIO *sio;
+	uint8_t index;
+	SuperIODevice *device;
+	SMC_RESULT readAccess() override;
+	SMC_RESULT update(const SMC_DATA *src) override;
+public:
+	ManualKey(const SMCSuperIO *sio, SuperIODevice *device, uint8_t index) : sio(sio), index(index), device(device) {}
+};
+
+class TargetKey : public VirtualSMCValue {
+protected:
+	const SMCSuperIO *sio;
+	uint8_t index;
+	SuperIODevice *device;
+	SMC_RESULT readAccess() override;
+	SMC_RESULT update(const SMC_DATA *src) override;
+public:
+	TargetKey(const SMCSuperIO *sio, SuperIODevice *device, uint8_t index) : sio(sio), index(index), device(device) {}
 };
 
 class VoltageKey : public VirtualSMCValue {

--- a/Sensors/SMCSuperIO/SuperIODevice.hpp
+++ b/Sensors/SMCSuperIO/SuperIODevice.hpp
@@ -38,6 +38,14 @@ protected:
 	 */
 	_Atomic(uint16_t) targets[MAX_TACHOMETER_COUNT] = { };
 	/**
+	 *	Max RPMs
+	 */
+	_Atomic(uint16_t) maxRpm[MAX_TACHOMETER_COUNT] = { };
+	/**
+	 *	Min RPMs
+	 */
+	_Atomic(uint16_t) minRpm[MAX_TACHOMETER_COUNT] = { };
+	/**
 	 * Manual contol
 	 */
 	_Atomic(uint8_t) manual[MAX_TACHOMETER_COUNT] = { };
@@ -275,6 +283,20 @@ public:
 		}
 		return 0.0f;
 	}
+	
+	uint16_t getMaxValue(uint8_t index) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			return atomic_load_explicit(&maxRpm[index], memory_order_relaxed);
+		}
+		return 0;
+	}
+	
+	uint16_t getMinValue(uint8_t index) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			return atomic_load_explicit(&minRpm[index], memory_order_relaxed);
+		}
+		return 0;
+	}
 
 	virtual const char* getModelName() = 0;
 	virtual uint8_t getLdn() { return EC_ENDPOINT; };
@@ -295,6 +317,18 @@ public:
 	virtual void setManualValue(uint8_t index, uint8_t value) {
 		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
 			atomic_store_explicit(&manual[index], value, memory_order_relaxed);
+		}
+	}
+	
+	virtual void setMaxValue(uint8_t index, uint16_t value) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			atomic_store_explicit(&maxRpm[index], value, memory_order_relaxed);
+		}
+	}
+
+	virtual void setMinValue(uint8_t index, uint16_t value) {
+		if (index < getTachometerCount() && index < MAX_TACHOMETER_COUNT) {
+			atomic_store_explicit(&minRpm[index], value, memory_order_relaxed);
 		}
 	}
 	/**

--- a/Tools/fanpwmgen/fanpwmgen.cpp
+++ b/Tools/fanpwmgen/fanpwmgen.cpp
@@ -7,7 +7,7 @@
 
 #include "fanpwmgen.hpp"
 
-int g_fan;
+int g_fan = -1;
 char *g_fanpwm;
 
 float fltToFpe2(uint16_t *str, int size) {

--- a/Tools/fanpwmgen/fanpwmgen.cpp
+++ b/Tools/fanpwmgen/fanpwmgen.cpp
@@ -13,14 +13,14 @@ float fltToFpe2(uint16_t *str, int size) {
   if (size != 2)
 	return 0;
 
-  return htons(*(uint16_t*)str) * 4.0f;
+  return _OSSwapInt16(*(uint16_t*)str << (16U - 0xe));
 }
 
 float fpe2ToFlt(char *str, int size) {
   if (size != 2)
 	return 0;
 
-  return ntohs(*(uint16_t*)str) / 4.0f;
+  return _OSSwapInt16(*(uint16_t*)str) >> (16U - 0xe);
 }
 
 void usage(char *prog) {
@@ -53,7 +53,7 @@ void setRpm(int fan, uint16_t rpm) {
 	bool result;
 
 	snprintf(val.key, 5, "F%xTg", fan);
-	
+
 	rpm = fltToFpe2(&rpm, 2);
 
 	memcpy(&val.bytes, &rpm, 2);
@@ -152,6 +152,11 @@ int main(int argc, char *argv[]) {
 			sleep(time * 3);
 		else
 			sleep(time);
+		// cause quickReschedule to be called so RPM data is updated
+		getRpm(fan);
+
+		// 100ms should be more than enough
+		usleep(100 * 1000);
 
 		rpm2 = getRpm(fan);
 

--- a/Tools/fanpwmgen/fanpwmgen.cpp
+++ b/Tools/fanpwmgen/fanpwmgen.cpp
@@ -1,0 +1,169 @@
+//
+//  fanpwmgen.cpp
+//  fanpwmgen
+//
+//  Copyright © 2023 xCuri0. All rights reserved.
+//
+
+#include "fanpwmgen.hpp"
+
+int g_fan;
+
+float fltToFpe2(uint16_t *str, int size) {
+  if (size != 2)
+	return 0;
+
+  return htons(*(uint16_t*)str) * 4.0f;
+}
+
+float fpe2ToFlt(char *str, int size) {
+  if (size != 2)
+	return 0;
+
+  return ntohs(*(uint16_t*)str) / 4.0f;
+}
+
+void usage(char *prog) {
+  printf("VirtualSMC fan#-pwm generation tool\n");
+  printf("Usage:\n");
+  printf("%s [options]\n", prog);
+  printf("    -f <num>   : the fan number to use\n");
+  printf("    -s <steps> : number of steps to use when generating curve, default 16 and max 256\n");
+  printf("    -t <time>  : time to wait before going to next step, default 2 seconds\n");
+  printf("    -h         : help\n");
+  printf("\n");
+}
+
+void setManual(int fan, bool manual) {
+	SMCVal_t val;
+	bool result;
+
+	snprintf(val.key, 5, "F%xMd", fan);
+	memcpy(&val.bytes, &manual, 1);
+	val.dataSize = 1;
+
+	result = SMCWriteKey(val);
+	if (!result) {
+	  fprintf(stderr, "Error: SMCWriteKey() = %08x\n", result);
+	}
+}
+
+void setRpm(int fan, uint16_t rpm) {
+	SMCVal_t val;
+	bool result;
+
+	snprintf(val.key, 5, "F%xTg", fan);
+	
+	rpm = fltToFpe2(&rpm, 2);
+
+	memcpy(&val.bytes, &rpm, 2);
+	val.dataSize = 2;
+
+	result = SMCWriteKey(val);
+	if (!result) {
+	  fprintf(stderr, "Error: SMCWriteKey() = %08x\n", result);
+	}
+}
+
+uint16_t getRpm(uint8_t fan) {
+	SMCVal_t val;
+	char keyS[5];
+
+	snprintf(keyS, 5, "F%xAc", fan);
+
+	if (!SMCReadKey(keyS, &val))
+		return 0;
+
+	return fpe2ToFlt(val.bytes, val.dataSize);
+	
+}
+
+void restoreAuto(int sig) {
+	printf("\nCTRL-C detected, restoring automatic fan control before exiting\n");
+	setManual(g_fan, false);
+	SMCClose();
+
+	exit(1);
+}
+
+int main(int argc, char *argv[]) {
+	int c;
+	extern char *optarg;
+	int fan = -1, steps = 15, time = 2;
+	uint16_t rpm = 0, rpm2 = 0;
+	char *fanpwm;
+
+	while ((c = getopt(argc, argv, "f:s:t:h")) != -1) {
+		switch (c) {
+			case 'f':
+				fan = atoi(optarg);
+				break;
+			case 's':
+				steps = atoi(optarg);
+				break;
+			case 't':
+				time = atoi(optarg);
+				break;
+			case 'h':
+				usage(argv[0]);
+				return 0;
+				break;
+		}
+	}
+	if (fan == -1) {
+		printf("please specify -f <num> to select fan to use\n\n");
+		usage(argv[0]);
+		return 1;
+	}
+	if (255 % steps) {
+		printf("steps <%d> doesn't multiply to 255\n", steps);
+
+		return 1;
+	}
+	if (geteuid() != 0) {
+		printf("run as root so that smc keys can be accessed\n");
+
+		return 1;
+	}
+	fanpwm = (char*)malloc((steps * 10) + 1); // max 10 chars for each section
+
+	printf("\e[1mAvoid high CPU/GPU load activity while this is running as your fans will slow down\e[m\n\n");
+	printf("\e[1mMake sure all fan control software is closed\e[m\n\n");
+	printf("\e[1mMake sure fan%d-pwm is not already set or output will be invalid\e[m\n\n", fan);
+
+	printf("setting fan #%d to manual control\n", fan);
+	printf("generating fan%d-pwm using %d steps waiting %d seconds on each\n", fan, steps, time);
+
+	g_fan = fan;
+
+	if (!SMCOpen())
+	  return 1;
+
+	setbuf(stdout, NULL);
+	signal(SIGINT, restoreAuto);
+	setManual(fan, true);
+
+	for (int i = 0; i <= 255; i += (255 / steps)) {
+		printf("pwm set to %d ", i);
+		setRpm(fan, i * (3315 / 255));
+
+		// give extra time for fan to spin down
+		if (i == 0)
+			sleep(time * 3);
+		else
+			sleep(time);
+
+		rpm2 = getRpm(fan);
+
+		if (rpm2 > rpm)
+			rpm = rpm2;
+
+		printf("rpm %d\n", rpm);
+		snprintf(fanpwm + strlen(fanpwm), (steps * 10) + 1 - strlen(fanpwm), "%d,%d|", rpm, i);
+	}
+	setManual(fan, false);
+	SMCClose();
+
+	printf("\ndone generating fan%d-pwm \n\n", fan);
+	printf("fan%d-pwm: %s\n", fan, fanpwm);
+}

--- a/Tools/fanpwmgen/fanpwmgen.hpp
+++ b/Tools/fanpwmgen/fanpwmgen.hpp
@@ -1,0 +1,105 @@
+//
+//  fanpwmgen.hpp
+//  fanpwmgen
+//
+//  Created by curi0 on 2023-05-26.
+//  Copyright © 2023 vit9696. All rights reserved.
+//
+
+#ifndef fanpwmgen_hpp
+#define fanpwmgen_hpp
+
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <string>
+#include <vector>
+
+#define OP_NONE 0
+#define OP_LIST 1
+#define OP_READ 2
+#define OP_READ_FAN 3
+#define OP_WRITE 4
+#define OP_FUZZ 5
+#define OP_COMPARE 6
+#define OP_CAST 7
+
+#define DATATYPE_FPE2 "fpe2"
+#define DATATYPE_UINT8 "ui8 "
+#define DATATYPE_UINT16 "ui16"
+#define DATATYPE_UINT32 "ui32"
+#define DATATYPE_SINT8 "si8 "
+#define DATATYPE_SINT16 "si16"
+#define DATATYPE_SINT32 "si32"
+#define DATATYPE_SP78 "sp78"
+
+// key values
+/*#define SMC_KEY_CPU_TEMP      "TC0D"
+#define SMC_KEY_FAN0_RPM_MIN  "F0Tg"
+#define SMC_KEY_FAN1_RPM_MIN  "F1Tg"
+#define SMC_KEY_FAN0_RPM_CUR  "F0Ac"
+#define SMC_KEY_FAN1_RPM_CUR  "F1Ac"*/
+
+typedef struct {
+  char major;
+  char minor;
+  char build;
+  char reserved[1];
+  uint16_t release;
+} SMCKeyData_vers_t;
+
+typedef struct {
+  uint16_t version;
+  uint16_t length;
+  uint32_t cpuPLimit;
+  uint32_t gpuPLimit;
+  uint32_t memPLimit;
+} SMCKeyData_pLimitData_t;
+
+typedef struct {
+  uint32_t dataSize;
+  uint32_t dataType;
+  char dataAttributes;
+} SMCKeyData_keyInfo_t;
+
+typedef char SMCBytes_t[32];
+
+typedef struct {
+  uint32_t key;
+  SMCKeyData_vers_t vers;
+  SMCKeyData_pLimitData_t pLimitData;
+  SMCKeyData_keyInfo_t keyInfo;
+  char result;
+  char status;
+  char data8;
+  uint32_t data32;
+  SMCBytes_t bytes;
+} SMCKeyData_t;
+
+typedef char UInt32Char_t[5];
+
+typedef struct {
+  UInt32Char_t key;
+  uint32_t dataSize;
+  UInt32Char_t dataType;
+  SMCBytes_t bytes;
+} SMCVal_t;
+
+// prototypes
+double SMCGetTemperature(char *key);
+bool SMCSetFanRpm(char *key, int32_t rpm);
+int SMCGetFanRpm(char *key);
+
+bool SMCOpen();
+bool SMCReadKey(const std::string &key, SMCVal_t *val);
+bool SMCWriteKey(SMCVal_t& writeVal);
+void SMCGetKeys(std::vector<std::string> &keys);
+bool SMCClose();
+uint32_t SMCReadIndexCount(void);
+
+uint32_t _strtoul(const char *str, int size, int base);
+void _ultostr(char *str, uint32_t val);
+
+#endif /* fanpwmgen_hpp */

--- a/Tools/smc-fuzzer/smc.cpp
+++ b/Tools/smc-fuzzer/smc.cpp
@@ -54,7 +54,7 @@ float fpe2ToFlt(char *str, int size) {
   if (size != 2)
     return 0;
 
-  uint16_t value = ((uint16_t)str[0] << 8) | (uint16_t)str[1];
+  uint16_t value = ntohs(*(uint16_t*)str);
   return value / 4.0f;
 }
 
@@ -254,7 +254,7 @@ bool SMCPrintFans(void) {
     snprintf(key, 5, "F%dSf", i);
     SMCReadKey(key, &val);
     printf("    Safe speed   : %.0f\n", fpe2ToFlt(val.bytes, val.dataSize));
-    sprintf(key, "F%dTg", i);
+    snprintf(key, 5, "F%xTg", i);
     SMCReadKey(key, &val);
     printf("    Target speed : %.0f\n", fpe2ToFlt(val.bytes, val.dataSize));
     SMCReadKey("FS! ", &val);

--- a/Tools/smc-fuzzer/smc.cpp
+++ b/Tools/smc-fuzzer/smc.cpp
@@ -26,30 +26,6 @@
 // When break key iteration into two steps: (1) discovery, (2) enumeration.
 std::vector<std::string> kSMCKeys;
 
-uint32_t _strtoul(const char *str, int size, int base) {
-  uint32_t total = 0;
-  int i;
-
-  for (i = 0; i < size; i++) {
-    if (base == 16)
-      total += str[i] << ((size - 1 - i) * 8);
-    else
-      total += (unsigned char)(str[i] << ((size - 1 - i) * 8));
-  }
-  return total;
-}
-
-void _ultostr(char *str, uint32_t val) {
-  str[0] = '\0';
-  snprintf(str,
-           5,
-           "%c%c%c%c",
-           (unsigned int)val >> 24,
-           (unsigned int)val >> 16,
-           (unsigned int)val >> 8,
-           (unsigned int)val);
-}
-
 float fpe2ToFlt(char *str, int size) {
   if (size != 2)
     return 0;
@@ -132,21 +108,6 @@ void printVal(SMCVal_t val) {
   } else {
     printf("no data\n");
   }
-}
-
-uint32_t SMCReadIndexCount(void) {
-  SMCVal_t val;
-  int num = 0;
-
-  SMCReadKey("#KEY", &val);
-  num = ((int)val.bytes[2] << 8) + ((unsigned)val.bytes[3] & 0xff);
-  printf("Num: b0=%x b1=%x b2=%x b3=%x size=%u\n",
-         val.bytes[0],
-         val.bytes[1],
-         val.bytes[2],
-         val.bytes[3],
-         (unsigned int)val.dataSize);
-  return num;
 }
 
 bool SMCPrintAll(const std::vector<std::string> &keys) {

--- a/Tools/smc-fuzzer/smc.cpp
+++ b/Tools/smc-fuzzer/smc.cpp
@@ -30,8 +30,7 @@ float fpe2ToFlt(char *str, int size) {
   if (size != 2)
     return 0;
 
-  uint16_t value = ntohs(*(uint16_t*)str);
-  return value / 4.0f;
+  return _OSSwapInt16(*(uint16_t*)str) >> (16U - 0xe);
 }
 
 void printFPE2(SMCVal_t val) {

--- a/Tools/smc-fuzzer/smc_mac.cpp
+++ b/Tools/smc-fuzzer/smc_mac.cpp
@@ -14,6 +14,30 @@
 // We only need 1 open connection, might as well be global.
 io_connect_t kIOConnection;
 
+uint32_t _strtoul(const char *str, int size, int base) {
+  uint32_t total = 0;
+  int i;
+
+  for (i = 0; i < size; i++) {
+	if (base == 16)
+	  total += str[i] << ((size - 1 - i) * 8);
+	else
+	  total += (unsigned char)(str[i] << ((size - 1 - i) * 8));
+  }
+  return total;
+}
+
+void _ultostr(char *str, uint32_t val) {
+  str[0] = '\0';
+  snprintf(str,
+		   5,
+		   "%c%c%c%c",
+		   (unsigned int)val >> 24,
+		   (unsigned int)val >> 16,
+		   (unsigned int)val >> 8,
+		   (unsigned int)val);
+}
+
 kern_return_t SMCCall(uint32_t selector,
             SMCKeyData_t *inputStructure,
             SMCKeyData_t *outputStructure) {
@@ -32,6 +56,21 @@ kern_return_t SMCCall(uint32_t selector,
   if (res != kIOReturnSuccess)
     printf("Error: IOConnectCallStructMethod 0x%x\n", res);
   return res;
+}
+
+uint32_t SMCReadIndexCount(void) {
+  SMCVal_t val;
+  int num = 0;
+
+  SMCReadKey("#KEY", &val);
+  num = ((int)val.bytes[2] << 8) + ((unsigned)val.bytes[3] & 0xff);
+  printf("Num: b0=%x b1=%x b2=%x b3=%x size=%u\n",
+		 val.bytes[0],
+		 val.bytes[1],
+		 val.bytes[2],
+		 val.bytes[3],
+		 (unsigned int)val.dataSize);
+  return num;
 }
 
 void SMCGetKeys(std::vector<std::string> &keys) {

--- a/Tools/smc-fuzzer/smc_mac.cpp
+++ b/Tools/smc-fuzzer/smc_mac.cpp
@@ -136,7 +136,7 @@ bool SMCWriteKey(SMCVal_t& writeVal) {
   SMCVal_t readVal;
 
   result = SMCReadKey(writeVal.key, &readVal);
-  if (result != kIOReturnSuccess) {
+  if (!result) {
     return false;
   }
 

--- a/VirtualSMC.xcodeproj/project.pbxproj
+++ b/VirtualSMC.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		ABE841652378A1ED003B5FEF /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = ABE841642378A1ED003B5FEF /* main.mm */; };
 		ABE841722378CB1C003B5FEF /* Devices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ABE841702378CB1C003B5FEF /* Devices.cpp */; };
 		ABE841742378CB1C003B5FEF /* Devices.hpp in Headers */ = {isa = PBXBuildFile; fileRef = ABE841712378CB1C003B5FEF /* Devices.hpp */; };
+		C83E35532A222D77008473F7 /* smc_mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2FBC32A623D8C40C00052675 /* smc_mac.cpp */; };
+		C83EEB142A20804100D936C3 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE09E8C81FFD20F90010A9CA /* IOKit.framework */; };
+		C8C9D88F2A2070C200769892 /* fanpwmgen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8C9D88D2A2070C200769892 /* fanpwmgen.cpp */; };
 		CE09E8C61FFD20EB0010A9CA /* smc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEC8039D1FFD206E008544A7 /* smc.cpp */; };
 		CE09E8C91FFD20F90010A9CA /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE09E8C81FFD20F90010A9CA /* IOKit.framework */; };
 		CE15935C1F50506200D61131 /* kern_keys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE15935A1F50506100D61131 /* kern_keys.cpp */; };
@@ -123,6 +126,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = ABE841612378A1ED003B5FEF;
 			remoteInfo = DeviceGenerator;
+		};
+		C8F3FEFB2A21EB71008D6FAA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1C748C1E1C21952C0024EED2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C8C9D8832A20707700769892;
+			remoteInfo = fanpwmgen;
 		};
 		CE147CD0218878B200536AE6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -236,6 +246,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		C8C9D8822A20707700769892 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		CE09E8BD1FFD20DB0010A9CA /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -323,6 +342,9 @@
 		ABE8416C2378A29B003B5FEF /* generate.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = generate.sh; sourceTree = "<group>"; };
 		ABE841702378CB1C003B5FEF /* Devices.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Devices.cpp; sourceTree = "<group>"; };
 		ABE841712378CB1C003B5FEF /* Devices.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Devices.hpp; sourceTree = "<group>"; };
+		C8C9D8842A20707700769892 /* fanpwmgen */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fanpwmgen; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8C9D88D2A2070C200769892 /* fanpwmgen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fanpwmgen.cpp; sourceTree = "<group>"; };
+		C8C9D88E2A2070C200769892 /* fanpwmgen.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = fanpwmgen.hpp; sourceTree = "<group>"; };
 		CE09E8BF1FFD20DB0010A9CA /* smc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = smc; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE09E8C81FFD20F90010A9CA /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		CE0F048B24A460CC00FA857B /* BATC-Sample.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "BATC-Sample.plist"; path = "Docs/BATC-Sample.plist"; sourceTree = "<group>"; };
@@ -473,6 +495,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8C9D8812A20707700769892 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C83EEB142A20804100D936C3 /* IOKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CE09E8BC1FFD20DB0010A9CA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -553,6 +583,7 @@
 				35A795E221B0597F005F2F6C /* CoreOffset */,
 				ABE841622378A1ED003B5FEF /* DeviceGenerator */,
 				F68156842496AFCF007C21AD /* SMCDellSensors.kext */,
+				C8C9D8842A20707700769892 /* fanpwmgen */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -704,6 +735,15 @@
 			path = DeviceGenerator;
 			sourceTree = "<group>";
 		};
+		C8C9D88C2A20709600769892 /* fanpwmgen */ = {
+			isa = PBXGroup;
+			children = (
+				C8C9D88D2A2070C200769892 /* fanpwmgen.cpp */,
+				C8C9D88E2A2070C200769892 /* fanpwmgen.hpp */,
+			);
+			path = fanpwmgen;
+			sourceTree = "<group>";
+		};
 		CE09E8C71FFD20F90010A9CA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -826,6 +866,7 @@
 		CEA5F65720B991BD008E6E8A /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				C8C9D88C2A20709600769892 /* fanpwmgen */,
 				35A795E321B0597F005F2F6C /* CoreOffset */,
 				CE335ADB2096738A00C60A5F /* rtcread */,
 				CE3BD6921F48BE1900A03466 /* smcread */,
@@ -971,6 +1012,7 @@
 				CEA5F66D20B9999C008E6E8A /* PBXTargetDependency */,
 				CEA5F66F20B9999C008E6E8A /* PBXTargetDependency */,
 				CEA5AABF2129AF8B0001F426 /* PBXTargetDependency */,
+				C8F3FEFC2A21EB71008D6FAA /* PBXTargetDependency */,
 			);
 			name = Package;
 			passBuildSettingsInEnvironment = 1;
@@ -1089,6 +1131,23 @@
 			name = DeviceGenerator;
 			productName = DeviceGenerator;
 			productReference = ABE841622378A1ED003B5FEF /* DeviceGenerator */;
+			productType = "com.apple.product-type.tool";
+		};
+		C8C9D8832A20707700769892 /* fanpwmgen */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C8C9D8882A20707700769892 /* Build configuration list for PBXNativeTarget "fanpwmgen" */;
+			buildPhases = (
+				C8C9D8802A20707700769892 /* Sources */,
+				C8C9D8812A20707700769892 /* Frameworks */,
+				C8C9D8822A20707700769892 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = fanpwmgen;
+			productName = fanpwmgen;
+			productReference = C8C9D8842A20707700769892 /* fanpwmgen */;
 			productType = "com.apple.product-type.tool";
 		};
 		CE09E8BE1FFD20DB0010A9CA /* smc-fuzzer */ = {
@@ -1227,6 +1286,10 @@
 						CreatedOnToolsVersion = 11.2;
 						ProvisioningStyle = Manual;
 					};
+					C8C9D8832A20707700769892 = {
+						CreatedOnToolsVersion = 14.3;
+						ProvisioningStyle = Automatic;
+					};
 					CE09E8BE1FFD20DB0010A9CA = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
@@ -1270,9 +1333,10 @@
 				ABE841612378A1ED003B5FEF /* DeviceGenerator */,
 				CE3BD6901F48BE1900A03466 /* smcread */,
 				CE09E8BE1FFD20DB0010A9CA /* smc-fuzzer */,
-				CE335AD92096738A00C60A5F /* rtcread */,
 				CEA5AAB62129AF3A0001F426 /* aistat */,
+				CE335AD92096738A00C60A5F /* rtcread */,
 				35A795E121B0597F005F2F6C /* CoreOffset */,
+				C8C9D8832A20707700769892 /* fanpwmgen */,
 			);
 		};
 /* End PBXProject section */
@@ -1452,6 +1516,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8C9D8802A20707700769892 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C83E35532A222D77008473F7 /* smc_mac.cpp in Sources */,
+				C8C9D88F2A2070C200769892 /* fanpwmgen.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CE09E8BB1FFD20DB0010A9CA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1525,6 +1598,11 @@
 			isa = PBXTargetDependency;
 			target = ABE841612378A1ED003B5FEF /* DeviceGenerator */;
 			targetProxy = ABE8416A2378A214003B5FEF /* PBXContainerItemProxy */;
+		};
+		C8F3FEFC2A21EB71008D6FAA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C8C9D8832A20707700769892 /* fanpwmgen */;
+			targetProxy = C8F3FEFB2A21EB71008D6FAA /* PBXContainerItemProxy */;
 		};
 		CE147CD1218878B200536AE6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2385,6 +2463,76 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Release;
+		};
+		C8C9D8892A20707700769892 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		C8C9D88A2A20707700769892 /* Sanitize */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Sanitize;
+		};
+		C8C9D88B2A20707700769892 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};
@@ -3408,6 +3556,16 @@
 				ABE841672378A1ED003B5FEF /* Debug */,
 				ABE841682378A1ED003B5FEF /* Sanitize */,
 				ABE841692378A1ED003B5FEF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C8C9D8882A20707700769892 /* Build configuration list for PBXNativeTarget "fanpwmgen" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C8C9D8892A20707700769892 /* Debug */,
+				C8C9D88A2A20707700769892 /* Sanitize */,
+				C8C9D88B2A20707700769892 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Working fan control for ITE SuperIOs

![image](https://github.com/acidanthera/VirtualSMC/assets/29529557/3b14ad21-323d-4ce0-84be-6afb3c4fa58c)

There are some issues however.
* ~~I can't figure out how to add the F#Md key without messing up all the SMC fan keys. For this reason it's commented out and it's not possible to restore automatic fan control by motherboard unless you reboot.~~
* ~~Hardcoded RPM ranges.~~
* ~~Control index doesn't always match the tachometer index which you can see in my screenshot (Fan Main uses control of Fan 2).~~
* Possible issues with code structure/style

So far it's only been tested on my Gigabyte B75M-D3H (IT8728F) but it should work on most ITE SuperIOs. I've used LibreHardwareMonitor's code to as a reference for the registers, etc.

~~**I'm also looking for suggestions of how to expose configuration (rpm/pwm curve, correcting index, hiding fans, etc). Currently planning on doing something similar to how it's done for EC Device**~~.

Configurable through `fan#-hide` (hide fan), `fan#-control` (set control index) and `fan#-pwm` (pwm curve)