### PR TITLE
add ite8638 support

### DIFF
--- a/Sensors/SMCSuperIO/Devices.cpp
+++ b/Sensors/SMCSuperIO/Devices.cpp
@@ -750,6 +750,24 @@ public:
 
 };
 
+class Device_0x8638 final : public GeneratedITEDevice_6 {
+public:
+	static SuperIODevice *createDevice(uint16_t deviceId) {
+		if (deviceId == 0x8638)
+			return new Device_0x8638();
+		return nullptr;
+	}
+
+	uint8_t getLdn() override {
+		return 0x04;
+	}
+
+	const char* getModelName() override {
+		return "ITE IT8638";
+	}
+
+};
+
 class Device_0x8686 final : public GeneratedITEDevice_6 {
 public:
 	static SuperIODevice *createDevice(uint16_t deviceId) {

--- a/Sensors/SMCSuperIO/ITEDevice.cpp
+++ b/Sensors/SMCSuperIO/ITEDevice.cpp
@@ -381,6 +381,7 @@ namespace ITE {
 			} else {
 				if (strcmp(detectedDevice->getModelName(), "ITE IT8721F") || strcmp(detectedDevice->getModelName(), "ITE IT8728F") || strcmp(detectedDevice->getModelName(), "ITE IT8665E") || strcmp(detectedDevice->getModelName(), "ITE IT8686E") || strcmp(detectedDevice->getModelName(), "ITE IT8688E") || strcmp(detectedDevice->getModelName(), "ITE IT8689E") ||
 					strcmp(detectedDevice->getModelName(), "ITE IT8795E") || strcmp(detectedDevice->getModelName(), "ITE IT8628E") ||
+					strcmp(detectedDevice->getModelName(), "ITE IT8638")  ||
 					strcmp(detectedDevice->getModelName(), "ITE IT8625E") || strcmp(detectedDevice->getModelName(), "ITE IT8620E") ||
 					strcmp(detectedDevice->getModelName(), "ITE IT8613E") || strcmp(detectedDevice->getModelName(), "ITE IT8792E") ||
 					strcmp(detectedDevice->getModelName(), "ITE IT8655E") || strcmp(detectedDevice->getModelName(), "ITE IT8631E"))

--- a/Sensors/SMCSuperIO/Resources/IT8721F.plist
+++ b/Sensors/SMCSuperIO/Resources/IT8721F.plist
@@ -32,6 +32,12 @@
 		</dict>
 		<dict>
 			<key>DisplayName</key>
+			<string>ITE IT8638</string>
+			<key>DeviceID</key>
+			<integer>0x8638</integer>
+		</dict>
+		<dict>
+			<key>DisplayName</key>
 			<string>ITE IT8686E</string>
 			<key>DeviceID</key>
 			<integer>0x8686</integer>


### PR DESCRIPTION
Add ITE 0x8638 Chip support for AMD Ryzen Hackintosh.

Testsed on Lenovo m75q gen2, macOS 13.7.