### PR TITLE
SMCBatteryManager improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 VirtualSMC Changelog
 ====================
+#### v1.3.8
+- Reduced unneeded power source notifications to remove repeated "PMRD: clamshell closed 0, disabled 0/0, desktopMode 0, ac 0" messages in kernel log
+- Fixed freezing of battery percentage when the battery is 100% charged initially but the system is connected to an insufficiently powerful AC adapter
+
 #### v1.3.7
 - Added constants for macOS 26 support
 

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -82,10 +82,6 @@ void BatteryManager::checkDevices() {
 
 	externalPowerNotify(externalPowerConnected);
 	DBGLOG("bmgr", "status batteriesConnected %d externalPowerConnected %d batteriesAreFull %d", batteriesConnected, externalPowerConnected, batteriesAreFull);
-	if (externalPowerConnected && batteriesAreFull) {
-		DBGLOG("bmgr", "no poll");
-		return;
-	}
 
 	if (decrementQuickPoll()) {
 		DBGLOG("bmgr", "quick poll");

--- a/Sensors/SMCBatteryManager/BatteryManager.cpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.cpp
@@ -80,7 +80,10 @@ void BatteryManager::checkDevices() {
 		externalPowerConnected = true;
 	}
 
-	externalPowerNotify(externalPowerConnected);
+	if (!initialCheckDevices || externalPowerConnected != prevExternalPowerConnected) {
+		externalPowerNotify(externalPowerConnected);
+		prevExternalPowerConnected = externalPowerConnected;
+	}
 	DBGLOG("bmgr", "status batteriesConnected %d externalPowerConnected %d batteriesAreFull %d", batteriesConnected, externalPowerConnected, batteriesAreFull);
 
 	if (decrementQuickPoll()) {

--- a/Sensors/SMCBatteryManager/BatteryManager.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManager.hpp
@@ -203,6 +203,11 @@ private:
 	 *  Initial device check on startup
 	 */
 	bool initialCheckDevices {false};
+    
+    /**
+     * Previous state to prevent notification spam
+     */
+    bool prevExternalPowerConnected {false};
 
 	/**
 	 *  Handle notification about battery or AC adapter (dis)connection

--- a/Sensors/SMCBatteryManager/BatteryManagerState.hpp
+++ b/Sensors/SMCBatteryManager/BatteryManagerState.hpp
@@ -136,6 +136,11 @@ struct BatteryManagerState {
 	 * Set of AC infos
 	 */
 	ACAdapterInfo acInfo[MaxAcAdaptersSupported] {};
+	
+	/**
+	 * Whether external power is connected
+	 */
+	bool externalPowerConnected {false};
 };
 
 #endif /* BatteryManagerState_hpp */


### PR DESCRIPTION
1. Post notification about external power status only when the status is changed, not on every refresh. It reduces the `PMRD: clamshell closed 0, disabled 0/0, desktopMode 0, ac 0` spam in kernel log.
2. Do not pause polling when running on AC power with a fully charged battery. The polling is needed in the following situation:
- The system is connected to a too weak power source, for example, a 20W iPhone charger.
- It was in sleep mode (or turned off), which allowed the battery to charge to 100%.
- The system was turned on.
In this case the battery is fully charged, external power source is connected, but the battery is actually draining, so we need to refresh its status periodically, or else it will continue to show 100% until the power is disconnected or it is drained completely.